### PR TITLE
Sort projects by updatedAt

### DIFF
--- a/carbonmark/components/pages/Projects/index.tsx
+++ b/carbonmark/components/pages/Projects/index.tsx
@@ -18,6 +18,10 @@ type Props = {
 export const Projects: NextPage<Props> = (props) => {
   const hasProjects = !!props.projects.length;
 
+  const sortedProjects =
+    hasProjects &&
+    props.projects.sort((a, b) => Number(b.updatedAt) - Number(a.updatedAt));
+
   return (
     <>
       <PageHead
@@ -28,8 +32,8 @@ export const Projects: NextPage<Props> = (props) => {
 
       <Layout>
         <div className={styles.list}>
-          {hasProjects &&
-            props.projects.map((project, index) => (
+          {sortedProjects &&
+            sortedProjects.map((project, index) => (
               <Link
                 key={project.key + "-" + index}
                 href={createProjectLink(project)}


### PR DESCRIPTION
## Description

Quick PR:

Forgot to sort projects by updatedAt on initial render.

Later the user can sort the projects again when this ticket is done
=> https://github.com/Atmosfearful/bezos-frontend/issues/18


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
