### PR TITLE
Projects: Show price of projects

### DIFF
--- a/carbonmark/components/pages/Projects/index.tsx
+++ b/carbonmark/components/pages/Projects/index.tsx
@@ -7,17 +7,19 @@ import { ProjectImage } from "components/ProjectImage";
 import { PageHead } from "components/shared/PageHead";
 import { Vintage } from "components/Vintage";
 import { createProjectLink } from "lib/createUrls";
+import { formatBigToPrice } from "lib/formatNumbers";
 import { NextPage } from "next";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import * as styles from "./styles";
-
 type Props = {
   projects: Project[];
 };
 
 export const Projects: NextPage<Props> = (props) => {
-  const hasProjects = !!props.projects.length;
+  const { locale } = useRouter();
 
+  const hasProjects = !!props.projects.length;
   const sortedProjects =
     hasProjects &&
     props.projects.sort((a, b) => Number(b.updatedAt) - Number(a.updatedAt));
@@ -47,6 +49,9 @@ export const Projects: NextPage<Props> = (props) => {
                   </div>
                   <div className={styles.cardContent}>
                     <Text t="h4">
+                      {formatBigToPrice(project.price, locale)}
+                    </Text>
+                    <Text t="h5">
                       {project.name || "! MISSING PROJECT NAME !"}
                     </Text>
                     <Text t="caption">{project.methodology}</Text>


### PR DESCRIPTION
## Description

Since this ticket is done => https://github.com/Atmosfearful/bezos-frontend/issues/29
the UI can safely render all best prices of each project on the Marketplace Index page.

## Related Ticket

Closes https://github.com/Atmosfearful/bezos-frontend/issues/29

## Changes

<img width="787" alt="Bildschirm­foto 2023-02-02 um 11 18 10" src="https://user-images.githubusercontent.com/95881624/216297778-698e1e64-7dfb-4046-92e2-a6b837e36ae2.png">


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
