### PR TITLE
Fix: do not validate already approved handles

### DIFF
--- a/carbonmark/components/pages/Users/SellerConnected/Forms/EditProfile.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/Forms/EditProfile.tsx
@@ -43,11 +43,11 @@ export const EditProfile: FC<Props> = (props) => {
 
   const fetchIsNewHandle = async (handle: string) => {
     try {
-      const existingUser = await getUser({
+      const handleFromApi = await getUser({
         user: handle,
         type: "handle",
       });
-      const apiHandle = existingUser?.handle || "";
+      const apiHandle = handleFromApi?.handle || "";
       return apiHandle.toLowerCase() !== handle.toLowerCase();
     } catch (error) {
       console.error(error);
@@ -135,42 +135,47 @@ export const EditProfile: FC<Props> = (props) => {
         <InputField
           id="handle"
           inputProps={{
-            disabled: !!props.user?.handle,
+            disabled: isExistingUser,
             placeholder: t({
               id: "user.edit.form.input.handle.placeholder",
               message: "Your unique handle",
             }),
             type: "text",
-            ...register("handle", {
-              required: {
-                value: true,
-                message: t({
-                  id: "user.edit.form.input.handle.required",
-                  message: "Handle is required",
-                }),
-              },
-              pattern: {
-                value: /^[a-zA-Z0-9]+$/, // no special characters!
-                message: t({
-                  id: "user.edit.form.input.handle.pattern",
-                  message: "Handle should contain any special characters",
-                }),
-              },
-              validate: {
-                isAddress: (v) =>
-                  !utils.isAddress(v) || // do not allow polygon addresses
-                  t({
-                    id: "user.edit.form.input.handle.no_polygon_address",
-                    message: "Handle should not be an address",
-                  }),
-                isNewHandle: async (v) =>
-                  (await fetchIsNewHandle(v)) || // ensure unique handles
-                  t({
-                    id: "user.edit.form.input.handle.handle_exists",
-                    message: "Sorry, this handle already exists",
-                  }),
-              },
-            }),
+            ...register(
+              "handle",
+              !isExistingUser // validate only if handle can be changed
+                ? {
+                    required: {
+                      value: true,
+                      message: t({
+                        id: "user.edit.form.input.handle.required",
+                        message: "Handle is required",
+                      }),
+                    },
+                    pattern: {
+                      value: /^[a-zA-Z0-9]+$/, // no special characters!
+                      message: t({
+                        id: "user.edit.form.input.handle.pattern",
+                        message: "Handle should contain any special characters",
+                      }),
+                    },
+                    validate: {
+                      isAddress: (v) =>
+                        !utils.isAddress(v) || // do not allow polygon addresses
+                        t({
+                          id: "user.edit.form.input.handle.no_polygon_address",
+                          message: "Handle should not be an address",
+                        }),
+                      isNewHandle: async (v) =>
+                        (await fetchIsNewHandle(v)) || // ensure unique handles
+                        t({
+                          id: "user.edit.form.input.handle.handle_exists",
+                          message: "Sorry, this handle already exists",
+                        }),
+                    },
+                  }
+                : undefined
+            ),
           }}
           label={t({
             id: "user.edit.form.input.handle.label",


### PR DESCRIPTION
## Description

A handle should be:
- unique and not already taken
- without special characters
- not a polygon address

This works, however on Carbon testing Land there are already test users with handles which do not match this validation.
This is because the validation was implemented later 🦈 

So, in order to not block testing users, this PR disabled the input validation for a handle if the user already exists!

## Fixes:

![handle](https://user-images.githubusercontent.com/95881624/216954051-bde802fd-027f-4769-9ad6-ddbf8b27c638.png)



## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
