### PR TITLE
add invalid network modal to shared

### DIFF
--- a/carbonmark/components/Layout/index.tsx
+++ b/carbonmark/components/Layout/index.tsx
@@ -4,6 +4,7 @@ import { concatAddress, useWeb3 } from "@klimadao/lib/utils";
 import { t } from "@lingui/macro";
 import Menu from "@mui/icons-material/Menu";
 import { ProjectsController } from "components/pages/Project/ProjectsController";
+import { InvalidNetworkModal } from "components/shared/InvalidNetworkModal";
 import { useResponsive } from "hooks/useResponsive";
 import { connectErrorStrings } from "lib/constants";
 import Link from "next/link";
@@ -121,8 +122,8 @@ export const Layout: FC<Props> = (props: Props) => {
                 }),
               },
             })}
+          <InvalidNetworkModal />
         </div>
-
         {isProjects && isMobile && (
           <ProjectsController className={styles.mobileProjectsController} />
         )}

--- a/carbonmark/components/shared/InvalidNetworkModal/index.tsx
+++ b/carbonmark/components/shared/InvalidNetworkModal/index.tsx
@@ -1,0 +1,78 @@
+import { ButtonPrimary, Text } from "@klimadao/lib/components";
+import { polygonNetworks } from "@klimadao/lib/constants";
+import { useWeb3 } from "@klimadao/lib/utils";
+import { Trans } from "@lingui/macro";
+import { FC, useEffect, useState } from "react";
+import { Modal } from "../Modal";
+import * as styles from "./styles";
+
+export const InvalidNetworkModal: FC = () => {
+  const { provider } = useWeb3();
+  const [showModal, setShowModal] = useState(false);
+  const onLoadProvider = async () => {
+    if (!provider) return;
+
+    // TODO: remove hardcoded chainId
+    const network = await provider.getNetwork();
+    if (!network) return;
+
+    if (
+      network.chainId !== polygonNetworks.mainnet.chainId &&
+      network.chainId !== polygonNetworks.testnet.chainId
+    ) {
+      setShowModal(true);
+    }
+  };
+
+  useEffect(() => {
+    if (provider) onLoadProvider();
+  }, [provider]);
+
+  const handleChangeNetwork = (net: "mainnet" | "testnet") => async () => {
+    const { hexChainId, rpcUrls, blockExplorerUrls, chainName } =
+      polygonNetworks[net];
+
+    const typedProvider = (provider as any)?.provider;
+    if (typedProvider && typeof typedProvider.request === "function") {
+      await typedProvider.request({
+        method: "wallet_addEthereumChain",
+        params: [
+          {
+            chainId: hexChainId,
+            chainName,
+            nativeCurrency: {
+              name: "MATIC",
+              symbol: "MATIC",
+              decimals: 18,
+            },
+            rpcUrls,
+            blockExplorerUrls,
+          },
+        ],
+      });
+    }
+  };
+
+  if (!showModal) return null;
+
+  return (
+    <Modal
+      title={
+        <Text t="h3">
+          ⚠ <Trans>Wrong Network</Trans>
+        </Text>
+      }
+      showModal={showModal}
+    >
+      <Text t="body3" color="lightest" style={{ fontWeight: "normal" }}>
+        <Trans>This app only works on Polygon Mainnet.</Trans>
+      </Text>
+      <div className={styles.switchButtonContainer}>
+        <ButtonPrimary
+          label={<Trans>Switch to Polygon</Trans>}
+          onClick={handleChangeNetwork("mainnet")}
+        />
+      </div>
+    </Modal>
+  );
+};

--- a/carbonmark/components/shared/InvalidNetworkModal/styles.ts
+++ b/carbonmark/components/shared/InvalidNetworkModal/styles.ts
@@ -1,0 +1,8 @@
+import { css } from "@emotion/css";
+
+export const switchButtonContainer = css`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.8rem;
+  margin-top: 1.6rem;
+`;


### PR DESCRIPTION
## Description
Moved invalid network check to shared and placed the modal in the Layout component.
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #46 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
