### PR TITLE
Validate Decimals

### DIFF
--- a/carbonmark/components/CreateListing/Form/index.tsx
+++ b/carbonmark/components/CreateListing/Form/index.tsx
@@ -135,6 +135,11 @@ export const CreateListingForm: FC<Props> = (props) => {
                     message: "Single Price is required",
                   }),
                 },
+                pattern: {
+                  // https://stackoverflow.com/questions/354044/what-is-the-best-u-s-currency-regex#:~:text=Number%3A%20Currency%20amount%20(cents%20optional)%20Optional%20thousands%20separators%3B%20optional%20two%2Ddigit%20fraction
+                  value: /^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\.[0-9]{2})?$/,
+                  message: "Please enter a correct price format",
+                },
                 min: {
                   value: 0.1,
                   message: t({


### PR DESCRIPTION
## Description
* add a regex to singleUnitPrice in AddListingForm that validates it against USD pattern
*  if an invalid format is inputted then it displays error message
- [ ] get string for error message that should be displayed

Resolves #16 

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
