### PR TITLE
Configure sourcemaps on preview deployments

### DIFF
--- a/carbonmark/next.config.js
+++ b/carbonmark/next.config.js
@@ -12,6 +12,8 @@ module.exports = async (phase, { defaultConfig }) => {
 
   const nextConfig = {
     reactStrictMode: true,
+    //Provide source maps on preview deployments
+    productionBrowserSourceMaps: !IS_PRODUCTION,
     async redirects() {
       return [
         {


### PR DESCRIPTION
## Description

Enable [productionBrowserSourceMaps](https://nextjs.org/docs/advanced-features/source-maps) when `NEXT_PUBLIC_VERCEL_ENV` !== "production"

In order to debug bugs only occurring on preview deployments

## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/7104689/219155679-239c1a2d-4c2d-4bfb-9b81-c01cd27f390d.png)|![image](https://user-images.githubusercontent.com/7104689/219155981-1688c8fe-9003-42e3-8dab-6a6677f92582.png)|


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
