### PR TITLE
add back to project details button

### DIFF
--- a/carbonmark/components/pages/Users/ProfileHeader/index.tsx
+++ b/carbonmark/components/pages/Users/ProfileHeader/index.tsx
@@ -1,9 +1,14 @@
 import { Trans } from "@lingui/macro";
+import KeyboardArrowLeft from "@mui/icons-material/KeyboardArrowLeft";
 import PermIdentityOutlinedIcon from "@mui/icons-material/PermIdentityOutlined";
+import { CarbonmarkButton } from "components/CarbonmarkButton";
 import { Text } from "components/Text";
 import Image from "next/legacy/image";
+import { useRouter } from "next/router";
+import { HistoryContext } from "pages/_app";
 import userLogo from "public/user_default_avatar.png";
-import { FC } from "react";
+import { FC, useContext, useEffect, useState } from "react";
+
 import * as styles from "./styles";
 
 type Props = {
@@ -13,43 +18,66 @@ type Props = {
 };
 
 export const ProfileHeader: FC<Props> = (props) => {
+  const router = useRouter();
+  const historyContext = useContext(HistoryContext);
+  const [showBackButton, setShowBackButton] = useState(false);
+
+  useEffect(() => {
+    setShowBackButton(historyContext?.[0] !== router.asPath);
+  }, [historyContext]);
+
   return (
-    <div className={styles.profileHeader}>
-      <div className={styles.profileLogo}>
-        {props.isCarbonmarkUser ? (
-          <Image
-            src={userLogo}
-            alt="Carbonmark User Logo"
-            width={50}
-            height={50}
-          />
-        ) : (
-          <PermIdentityOutlinedIcon className="notRegisteredSvg" />
-        )}
+    <>
+      {!!showBackButton && (
+        <CarbonmarkButton
+          label={
+            <div className={styles.backToResults}>
+              <KeyboardArrowLeft className="arrow" />
+              <Trans id="profile.back_to_project_details">
+                Back to project details
+              </Trans>
+            </div>
+          }
+          onClick={() => router.back()}
+        />
+      )}
+      <div className={styles.profileHeader}>
+        <div className={styles.profileLogo}>
+          {props.isCarbonmarkUser ? (
+            <Image
+              src={userLogo}
+              alt="Carbonmark User Logo"
+              width={50}
+              height={50}
+            />
+          ) : (
+            <PermIdentityOutlinedIcon className="notRegisteredSvg" />
+          )}
+        </div>
+        <div className={styles.profileText}>
+          <Text t="h4">{props.userName}</Text>
+
+          {!props.isCarbonmarkUser && (
+            <Text t="body1">
+              <Trans id="profile.create_your_profile">
+                Create your profile on Carbonmark and start selling
+              </Trans>
+            </Text>
+          )}
+
+          {props.isCarbonmarkUser && !props.description && (
+            <Text t="body1">
+              <Trans id="profile.edit_your_profile">
+                Edit your profile to add a description
+              </Trans>
+            </Text>
+          )}
+
+          {props.isCarbonmarkUser && props.description && (
+            <Text t="body1">{props.description}</Text>
+          )}
+        </div>
       </div>
-      <div className={styles.profileText}>
-        <Text t="h4">{props.userName}</Text>
-
-        {!props.isCarbonmarkUser && (
-          <Text t="body1">
-            <Trans id="profile.create_your_profile">
-              Create your profile on Carbonmark and start selling
-            </Trans>
-          </Text>
-        )}
-
-        {props.isCarbonmarkUser && !props.description && (
-          <Text t="body1">
-            <Trans id="profile.edit_your_profile">
-              Edit your profile to add a description
-            </Trans>
-          </Text>
-        )}
-
-        {props.isCarbonmarkUser && props.description && (
-          <Text t="body1">{props.description}</Text>
-        )}
-      </div>
-    </div>
+    </>
   );
 };

--- a/carbonmark/components/pages/Users/ProfileHeader/styles.tsx
+++ b/carbonmark/components/pages/Users/ProfileHeader/styles.tsx
@@ -13,6 +13,13 @@ export const profileHeader = css`
   }
 `;
 
+export const backToResults = css`
+  gap: 1.6rem;
+  display: flex;
+  align-items: center;
+  color: var(--font-01) !important;
+`;
+
 export const profileLogo = css`
   width: 10rem;
   height: 10rem;

--- a/carbonmark/locale/en-pseudo/messages.po
+++ b/carbonmark/locale/en-pseudo/messages.po
@@ -13,37 +13,41 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: components/pages/errors/Custom404.tsx:13
 #: components/pages/errors/Custom404.tsx:14
 #: components/pages/errors/Custom404.tsx:15
-#: components/pages/errors/Custom404.tsx:16
-#: components/pages/errors/Custom404.tsx:23
+#: components/pages/errors/Custom404.tsx:22
 msgid "404 - Page Not Found"
 msgstr ""
 
+#: components/pages/errors/Custom500.tsx:13
 #: components/pages/errors/Custom500.tsx:14
 #: components/pages/errors/Custom500.tsx:15
-#: components/pages/errors/Custom500.tsx:16
 msgid "500 - Server Error"
 msgstr ""
 
-#: components/pages/errors/Custom500.tsx:23
+#: components/pages/errors/Custom500.tsx:22
 msgid "500 - Server error occurred"
 msgstr ""
 
-#: components/Stats/index.tsx:65
+#: components/Stats/index.tsx:62
 msgid "Active listings:"
 msgstr ""
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:151
-#: components/pages/Project/Purchase/PurchaseForm.tsx:184
+#: components/ProjectFilterModal/index.tsx:64
+msgid "Apply"
+msgstr ""
+
+#: components/pages/Project/Purchase/PurchaseForm.tsx:152
+#: components/pages/Project/Purchase/PurchaseForm.tsx:185
 msgid "Available:"
 msgstr ""
 
-#: components/pages/Projects/index.tsx:32
+#: components/pages/Projects/index.tsx:33
 msgid "Browse Carbon Projects | Carbonmark"
 msgstr ""
 
-#: components/pages/Projects/index.tsx:33
+#: components/pages/Projects/index.tsx:34
 msgid "Browse our massive inventory of verified carbon offset projects. Buy, sell, or offset in a few clicks."
 msgstr ""
 
@@ -51,35 +55,47 @@ msgstr ""
 msgid "Built with 🌳 by <0>KlimaDAO</0>"
 msgstr ""
 
-#: components/pages/Resources/index.tsx:24
+#: components/pages/Resources/index.tsx:23
 msgid "CarbonMark News & Resources"
 msgstr ""
 
-#: components/pages/Resources/index.tsx:23
+#: components/pages/Resources/index.tsx:22
 msgid "CarbonMark | Resources"
 msgstr ""
 
-#: components/pages/Home/index.tsx:18
+#: components/pages/Home/index.tsx:19
 msgid "Carbonmark | Universal Carbon Market"
 msgstr ""
 
-#: components/pages/Home/index.tsx:17
+#: components/pages/Home/index.tsx:18
 msgid "Carbonmark.com"
+msgstr ""
+
+#: components/ProjectFilterModal/index.tsx:56
+msgid "Category"
 msgstr ""
 
 #: components/shared/ChangeLanguageButton/index.tsx:48
 msgid "Change language"
 msgstr ""
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:37
+#: components/ProjectFilterModal/index.tsx:68
+msgid "Clear Filters"
+msgstr ""
+
+#: components/pages/Project/Purchase/PurchaseForm.tsx:38
 msgid "Cost incl. {0}% fee"
+msgstr ""
+
+#: components/ProjectFilterModal/index.tsx:53
+msgid "Country"
 msgstr ""
 
 #: components/pages/Project/ProjectListing/index.tsx:58
 msgid "Created:"
 msgstr ""
 
-#: components/pages/Project/index.tsx:132
+#: components/pages/Project/index.tsx:131
 msgid "Description"
 msgstr ""
 
@@ -87,11 +103,11 @@ msgstr ""
 msgid "Enter App"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:107
+#: components/pages/Purchases/index.tsx:105
 msgid "Final price"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:153
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:154
 msgid "Handle should not contain any special characters"
 msgstr ""
 
@@ -99,17 +115,17 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:178
+#: components/pages/Users/SellerConnected/index.tsx:173
 #: components/pages/Users/SellerUnconnected/index.tsx:50
 msgid "Listings"
 msgstr ""
 
-#: components/pages/Portfolio/index.tsx:148
+#: components/pages/Portfolio/index.tsx:149
 msgid "Loading your data..."
 msgstr ""
 
 #: components/LoginCard/index.tsx:34
-#: components/pages/Project/Purchase/PurchaseForm.tsx:187
+#: components/pages/Project/Purchase/PurchaseForm.tsx:188
 msgid "Loading..."
 msgstr ""
 
@@ -137,21 +153,29 @@ msgstr ""
 msgid "Marketplace"
 msgstr ""
 
-#: components/pages/Project/index.tsx:150
+#: components/pages/Project/index.tsx:149
 msgid "No listings found for this project."
 msgstr ""
 
-#: components/Layout/AddressSection/index.tsx:20
+#: components/Layout/AddressSection/index.tsx:21
 msgid "Not Connected"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:63
+#: components/pages/Purchases/index.tsx:61
 msgid "Payment Successful"
 msgstr ""
 
-#: components/pages/Portfolio/index.tsx:122
-#: components/pages/Users/SellerConnected/index.tsx:158
+#: components/pages/Portfolio/index.tsx:123
+#: components/pages/Users/SellerConnected/index.tsx:153
 msgid "Please refresh the page. There was an error updating your data: {e}."
+msgstr ""
+
+#: components/ProjectFilterModal/constants.tsx:8
+msgid "Price Highest"
+msgstr ""
+
+#: components/ProjectFilterModal/constants.tsx:9
+msgid "Price Lowest"
 msgstr ""
 
 #: components/Footer/index.tsx:33
@@ -160,16 +184,16 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:116
+#: components/pages/Purchases/index.tsx:114
 msgid "Project"
 msgstr ""
 
-#: components/pages/Projects/index.tsx:31
+#: components/pages/Projects/index.tsx:32
 msgid "Projects | Carbonmark"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:37
-#: components/pages/Purchases/index.tsx:38
+#: components/pages/Purchases/index.tsx:35
+#: components/pages/Purchases/index.tsx:36
 msgid "Purchase Receipt | Carbonmark"
 msgstr ""
 
@@ -183,8 +207,12 @@ msgstr ""
 msgid "Quantity Available:"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:98
+#: components/pages/Purchases/index.tsx:96
 msgid "Quantity purchased:"
+msgstr ""
+
+#: components/ProjectFilterModal/constants.tsx:10
+msgid "Recently Updated"
 msgstr ""
 
 #: components/Footer/index.tsx:36
@@ -205,52 +233,56 @@ msgstr ""
 msgid "Seller Listing"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:109
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:110
 msgid "Something went wrong. Please try again. {error}"
 msgstr ""
 
-#: components/pages/errors/Custom404.tsx:26
+#: components/pages/errors/Custom404.tsx:25
 msgid "Sorry, looks like we sent you the wrong way."
 msgstr ""
 
-#: components/pages/errors/Custom500.tsx:26
+#: components/pages/errors/Custom500.tsx:25
 msgid "Sorry, something went wrong."
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:165
 msgid "Sorry, this handle already exists"
 msgstr ""
 
-#: components/pages/Portfolio/index.tsx:178
+#: components/pages/Portfolio/index.tsx:179
 msgid "Success. Go to your <0>Profile page</0> to see your new listing."
 msgstr ""
 
-#: components/shared/InvalidNetworkModal/index.tsx:72
+#: components/shared/InvalidNetworkModal/index.tsx:74
 msgid "Switch to Polygon"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:74
+#: components/pages/Purchases/index.tsx:72
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr ""
 
-#: components/pages/Home/index.tsx:19
+#: components/pages/Home/index.tsx:20
 msgid "The open platform for digital carbon."
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:121
+#: components/pages/Users/SellerConnected/index.tsx:116
 msgid "There was an error getting your data: {error}"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:84
+#: components/pages/Users/SellerConnected/index.tsx:79
 msgid "There was an error loading your assets. {e}"
 msgstr ""
 
-#: components/shared/InvalidNetworkModal/index.tsx:68
+#: components/shared/InvalidNetworkModal/index.tsx:70
 msgid "This app only works on Polygon Mainnet."
 msgstr ""
 
 #: components/pages/Project/Purchase/index.tsx:208
 msgid "This offer no longer exists."
+msgstr ""
+
+#: components/Dropdown/index.tsx:72
+msgid "Toggle sort menu"
 msgstr ""
 
 #: components/Stats/index.tsx:55
@@ -265,11 +297,11 @@ msgstr ""
 msgid "Updated:"
 msgstr ""
 
-#: components/pages/Resources/index.tsx:25
+#: components/pages/Resources/index.tsx:24
 msgid "Updates, guides and more from the CarbonMark team"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:232
+#: components/pages/Users/SellerConnected/index.tsx:227
 msgid "Updating your data..."
 msgstr ""
 
@@ -278,31 +310,43 @@ msgstr ""
 msgid "User Profile | Carbonmark"
 msgstr ""
 
-#: components/pages/Users/index.tsx:47
+#: components/pages/Users/index.tsx:46
 msgid "View seller listings, carbon market activity and more."
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:31
+#: components/pages/Purchases/index.tsx:29
 msgid "View the project details and other info for this purchase."
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:67
+#: components/ProjectFilterModal/index.tsx:63
+msgid "Vintage"
+msgstr ""
+
+#: components/ProjectFilterModal/constants.tsx:11
+msgid "Vintage Newest"
+msgstr ""
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Vintage Oldest"
+msgstr ""
+
+#: components/pages/Purchases/index.tsx:65
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
 msgstr ""
 
-#: components/pages/Portfolio/index.tsx:190
+#: components/pages/Portfolio/index.tsx:191
 msgid "We couldn't find any C3 tokens in your connected wallet :("
 msgstr ""
 
-#: components/shared/InvalidNetworkModal/index.tsx:62
+#: components/shared/InvalidNetworkModal/index.tsx:64
 msgid "Wrong Network"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:103
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:104
 msgid "You chose to reject the transaction."
 msgstr ""
 
-#: components/Layout/AddressSection/index.tsx:16
+#: components/Layout/AddressSection/index.tsx:17
 msgid "Your Wallet Address:"
 msgstr ""
 
@@ -335,11 +379,11 @@ msgid "activity.you"
 msgstr ""
 
 #. Long sentence
-#: components/pages/Blog/Post/index.tsx:88
+#: components/pages/Blog/Post/index.tsx:85
 msgid "blog.disclaimer.description"
 msgstr ""
 
-#: components/pages/Blog/Post/index.tsx:85
+#: components/pages/Blog/Post/index.tsx:82
 msgid "blog.disclaimer.title"
 msgstr ""
 
@@ -359,11 +403,11 @@ msgstr ""
 msgid "connect_modal.connecting"
 msgstr ""
 
-#: lib/constants.ts:22
+#: lib/constants.ts:15
 msgid "connect_modal.error_message_default"
 msgstr ""
 
-#: lib/constants.ts:26
+#: lib/constants.ts:19
 msgid "connect_modal.error_message_refused"
 msgstr ""
 
@@ -391,52 +435,56 @@ msgstr ""
 msgid "portfolio.balances.title"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:163
+#: components/CreateListing/Form/index.tsx:165
 msgid "profile.addListing_modal.submit"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:205
+#: components/pages/Users/ProfileHeader/index.tsx:36
+msgid "profile.back_to_project_details"
+msgstr ""
+
+#: components/pages/Users/SellerConnected/index.tsx:200
 msgid "profile.create_new_listing"
 msgstr ""
 
-#: components/pages/Users/ProfileHeader/index.tsx:36
+#: components/pages/Users/ProfileHeader/index.tsx:62
 msgid "profile.create_your_profile"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:142
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:143
 msgid "profile.editListing_modal.submit"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:228
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:229
 msgid "profile.edit_modal.submit"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:263
+#: components/pages/Users/SellerConnected/index.tsx:258
 msgid "profile.edit_profile.title"
 msgstr ""
 
-#: components/pages/Users/ProfileHeader/index.tsx:44
+#: components/pages/Users/ProfileHeader/index.tsx:70
 msgid "profile.edit_your_profile"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:146
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:144
 msgid "profile.listing.delete.error"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:161
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:159
 msgid "profile.listing.edit"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:189
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:187
 msgid "profile.listing.edit.delete_listing"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/index.tsx:190
+#: components/pages/Users/SellerConnected/index.tsx:185
 #: components/pages/Users/SellerUnconnected/index.tsx:56
 msgid "profile.listings.empty_state"
 msgstr ""
 
-#: components/CreateListing/index.tsx:120
+#: components/CreateListing/index.tsx:121
 msgid "profile.listings_modal.title"
 msgstr ""
 
@@ -468,7 +516,7 @@ msgstr ""
 msgid "project.category.renewable_energy"
 msgstr ""
 
-#: components/pages/Project/index.tsx:99
+#: components/pages/Project/index.tsx:98
 msgid "project.single.best_price"
 msgstr ""
 
@@ -476,11 +524,11 @@ msgstr ""
 msgid "project.single.button.back_to_project"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:50
+#: components/pages/Purchases/index.tsx:48
 msgid "project.single.button.back_to_project_details"
 msgstr ""
 
-#: components/pages/Project/index.tsx:57
+#: components/pages/Project/index.tsx:56
 msgid "project.single.button.back_to_projects"
 msgstr ""
 
@@ -488,7 +536,7 @@ msgstr ""
 msgid "project.single.header.seller"
 msgstr ""
 
-#: components/pages/Project/index.tsx:106
+#: components/pages/Project/index.tsx:105
 msgid "project.single.methodology"
 msgstr ""
 
@@ -500,43 +548,43 @@ msgstr ""
 msgid "props.transaction.conjunction.at"
 msgstr ""
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:210
+#: components/pages/Project/Purchase/PurchaseForm.tsx:211
 msgid "purchase.button.continue"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:131
+#: components/pages/Purchases/index.tsx:129
 msgid "purchase.button.view_assets"
 msgstr ""
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:144
+#: components/pages/Project/Purchase/PurchaseForm.tsx:145
 msgid "purchase.input.amount.label"
 msgstr ""
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:137
+#: components/pages/Project/Purchase/PurchaseForm.tsx:138
 msgid "purchase.input.amount.maxAmount"
 msgstr ""
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:130
+#: components/pages/Project/Purchase/PurchaseForm.tsx:131
 msgid "purchase.input.amount.minimum"
 msgstr ""
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:112
+#: components/pages/Project/Purchase/PurchaseForm.tsx:113
 msgid "purchase.input.amount.placeholder"
 msgstr ""
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:123
+#: components/pages/Project/Purchase/PurchaseForm.tsx:124
 msgid "purchase.input.amount.required"
 msgstr ""
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:167
+#: components/pages/Project/Purchase/PurchaseForm.tsx:168
 msgid "purchase.input.price.maxAmount"
 msgstr ""
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:160
+#: components/pages/Project/Purchase/PurchaseForm.tsx:161
 msgid "purchase.input.price.required"
 msgstr ""
 
-#: components/pages/Project/Purchase/index.tsx:84
+#: components/pages/Project/Purchase/index.tsx:83
 msgid "purchase.loading.allowance.error"
 msgstr ""
 
@@ -552,27 +600,27 @@ msgstr ""
 msgid "purchase.transaction.modal.title.processing"
 msgstr ""
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:24
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
 msgid "resources.form.categories.header"
 msgstr ""
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:27
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
 msgid "resources.form.categories.subheader"
 msgstr ""
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:53
+#: components/pages/Resources/ResourcesFilters/index.tsx:51
 msgid "resources.form.filters.clear_all"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:177
+#: components/pages/Resources/ResourcesList/index.tsx:170
 msgid "resources.form.input.search.label"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:168
+#: components/pages/Resources/ResourcesList/index.tsx:161
 msgid "resources.form.input.search.placeholder"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:201
+#: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "resources.form.input.sort_by.label"
 msgstr ""
 
@@ -580,7 +628,7 @@ msgstr ""
 msgid "resources.form.input.sort_by.select"
 msgstr ""
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:41
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
 msgid "resources.form.sub_topics.header"
 msgstr ""
 
@@ -649,43 +697,43 @@ msgstr ""
 msgid "resources.list.sort_by.z-a"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:302
+#: components/pages/Resources/ResourcesList/index.tsx:295
 msgid "resources.mobile_modal.button.show_results"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:275
+#: components/pages/Resources/ResourcesList/index.tsx:268
 msgid "resources.mobile_modal.title"
 msgstr ""
 
-#: components/pages/Resources/index.tsx:37
+#: components/pages/Resources/index.tsx:36
 msgid "resources.page.header.subline"
 msgstr ""
 
-#: components/pages/Resources/index.tsx:34
+#: components/pages/Resources/index.tsx:33
 msgid "resources.page.header.title"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:159
+#: components/pages/Resources/ResourcesList/index.tsx:152
 msgid "resources.page.list.header"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:240
+#: components/pages/Resources/ResourcesList/index.tsx:233
 msgid "resources.page.list.no_search_results.title"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:232
+#: components/pages/Resources/ResourcesList/index.tsx:225
 msgid "resources.page.list.on_fetch_error"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:253
+#: components/pages/Resources/ResourcesList/index.tsx:246
 msgid "resources.page.list.search_submit.no_filter_results"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:246
+#: components/pages/Resources/ResourcesList/index.tsx:239
 msgid "resources.page.list.search_submit.no_search_results"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:169
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:167
 msgid "seller.edit_listing.title"
 msgstr ""
 
@@ -693,16 +741,16 @@ msgstr ""
 msgid "seller.listing.buy"
 msgstr ""
 
-#: components/pages/Users/Listing/index.tsx:39
+#: components/pages/Users/Listing/index.tsx:36
 msgid "seller.listing.quantity_available"
 msgstr ""
 
-#: components/Transaction/Approve.tsx:112
+#: components/Transaction/Approve.tsx:109
 msgid "shared.approve"
 msgstr ""
 
 #: components/pages/Project/ProjectListing/index.tsx:70
-#: components/pages/Project/Purchase/PurchaseForm.tsx:196
+#: components/pages/Project/Purchase/PurchaseForm.tsx:197
 #: components/pages/Users/SellerUnconnected/index.tsx:73
 msgid "shared.connect_to_buy"
 msgstr ""
@@ -711,16 +759,16 @@ msgstr ""
 msgid "shared.enter_app"
 msgstr ""
 
-#: components/pages/Blog/Post/index.tsx:71
+#: components/pages/Blog/Post/index.tsx:68
 msgid "shared.resourcecenter"
 msgstr ""
 
-#: components/pages/Resources/ResourcesList/index.tsx:207
+#: components/pages/Resources/ResourcesList/index.tsx:200
 msgid "shared.resources.sort_by.header"
 msgstr ""
 
-#: components/CreateListing/index.tsx:145
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:216
+#: components/CreateListing/index.tsx:146
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:214
 msgid "tonnes.long"
 msgstr ""
 
@@ -728,11 +776,11 @@ msgstr ""
 msgid "tonnes.short"
 msgstr ""
 
-#: components/CreateListing/index.tsx:154
+#: components/CreateListing/index.tsx:155
 msgid "transaction.create_listing.approval_description"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:225
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:223
 msgid "transaction.edit_listing.approval_description"
 msgstr ""
 
@@ -756,177 +804,177 @@ msgstr ""
 msgid "transaction.status.user_rejected"
 msgstr ""
 
-#: components/Transaction/Approve.tsx:65
+#: components/Transaction/Approve.tsx:62
 msgid "transaction_modal.approve.amount"
 msgstr ""
 
-#: components/Transaction/Approve.tsx:55
+#: components/Transaction/Approve.tsx:52
 msgid "transaction_modal.approve.contract_address"
 msgstr ""
 
-#: components/Transaction/Approve.tsx:81
+#: components/Transaction/Approve.tsx:78
 msgid "transaction_modal.approve.price"
 msgstr ""
 
-#: components/Transaction/Approve.tsx:47
+#: components/Transaction/Approve.tsx:44
 msgid "transaction_modal.approve.title"
 msgstr ""
 
-#: components/Transaction/index.tsx:88
+#: components/Transaction/index.tsx:87
 msgid "transaction_modal.button.go_back"
 msgstr ""
 
-#: components/Transaction/Submit.tsx:117
+#: components/Transaction/Submit.tsx:115
 msgid "transaction_modal.close"
 msgstr ""
 
-#: components/Transaction/Approve.tsx:120
+#: components/Transaction/Approve.tsx:117
 msgid "transaction_modal.next"
 msgstr ""
 
-#: components/Transaction/Submit.tsx:64
+#: components/Transaction/Submit.tsx:62
 msgid "transaction_modal.submit.amount"
 msgstr ""
 
-#: components/Transaction/Submit.tsx:109
+#: components/Transaction/Submit.tsx:107
 msgid "transaction_modal.submit.button"
 msgstr ""
 
-#: components/Transaction/Submit.tsx:54
+#: components/Transaction/Submit.tsx:52
 msgid "transaction_modal.submit.contract_address"
 msgstr ""
 
-#: components/Transaction/Submit.tsx:78
+#: components/Transaction/Submit.tsx:76
 msgid "transaction_modal.submit.price"
 msgstr ""
 
-#: components/Transaction/Submit.tsx:46
+#: components/Transaction/Submit.tsx:44
 msgid "transaction_modal.submit.title"
 msgstr ""
 
-#: components/Transaction/index.tsx:48
+#: components/Transaction/index.tsx:47
 msgid "transaction_modal.view.approve.title"
 msgstr ""
 
-#: components/Transaction/index.tsx:58
+#: components/Transaction/index.tsx:57
 msgid "transaction_modal.view.submit.title"
 msgstr ""
 
-#: components/Activities/index.tsx:31
+#: components/Activities/index.tsx:32
 msgid "user.activities.empty_state"
 msgstr ""
 
-#: components/Activities/index.tsx:26
+#: components/Activities/index.tsx:27
 msgid "user.activities.title"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:133
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:134
 msgid "user.edit.edit.input.price.label"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:109
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:110
 msgid "user.edit.form.edit.price.placeholder"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:97
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:98
 msgid "user.edit.form.edit.quantity.label"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:211
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:212
 msgid "user.edit.form.input.description.label"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:205
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:206
 msgid "user.edit.form.input.description.placeholder"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:170
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:171
 msgid "user.edit.form.input.handle.label"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:158
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:159
 msgid "user.edit.form.input.handle.no_polygon_address"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:135
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:136
 msgid "user.edit.form.input.handle.placeholder"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:146
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:147
 msgid "user.edit.form.input.handle.required"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:154
+#: components/CreateListing/Form/index.tsx:156
 msgid "user.edit.form.input.singleUnitPrice.label"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:125
+#: components/CreateListing/Form/index.tsx:127
 msgid "user.edit.form.input.singleUnitPrice.placeholder"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:113
+#: components/CreateListing/Form/index.tsx:115
 msgid "user.edit.form.input.totalAmountToSell.label"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:195
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:196
 msgid "user.edit.form.input.username.label"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:180
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
 msgid "user.edit.form.input.username.placeholder"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:188
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:189
 msgid "user.edit.form.input.username.required"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:90
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:91
 msgid "user.listing.edit.input.quantity.maxAmount"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:83
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:84
 msgid "user.listing.edit.input.quantity.minimum"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:68
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:69
 msgid "user.listing.edit.input.quantity.placeholder"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:76
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:77
 msgid "user.listing.edit.input.quantity.required"
 msgstr ""
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:48
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:49
 msgid "user.listing.edit.project.label"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:60
+#: components/CreateListing/Form/index.tsx:62
 msgid "user.listing.form.input.select_project.label"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:145
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:124
+#: components/CreateListing/Form/index.tsx:147
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:125
 msgid "user.listing.form.input.singleUnitPrice.minimum"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:133
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:117
+#: components/CreateListing/Form/index.tsx:135
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:118
 msgid "user.listing.form.input.singleUnitPrice.required"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:106
+#: components/CreateListing/Form/index.tsx:108
 msgid "user.listing.form.input.totalAmountToSell.maxAmount"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:99
+#: components/CreateListing/Form/index.tsx:101
 msgid "user.listing.form.input.totalAmountToSell.minimum"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:84
+#: components/CreateListing/Form/index.tsx:86
 msgid "user.listing.form.input.totalAmountToSell.placeholder"
 msgstr ""
 
-#: components/CreateListing/Form/index.tsx:92
+#: components/CreateListing/Form/index.tsx:94
 msgid "user.listing.form.input.totalAmountToSell.required"
 msgstr ""
 
@@ -946,20 +994,20 @@ msgstr ""
 msgid "user.stats.title"
 msgstr ""
 
-#: components/pages/Portfolio/index.tsx:202
-#: components/pages/Users/SellerConnected/index.tsx:250
+#: components/pages/Portfolio/index.tsx:203
+#: components/pages/Users/SellerConnected/index.tsx:245
 msgid "user.stats.your_seller_data.description"
 msgstr ""
 
+#: components/pages/Project/index.tsx:47
 #: components/pages/Project/index.tsx:48
-#: components/pages/Project/index.tsx:49
 msgid "{0} | Carbonmark"
 msgstr ""
 
-#: components/pages/Users/index.tsx:41
+#: components/pages/Users/index.tsx:40
 msgid "{0} | Profile | Carbonmark"
 msgstr ""
 
-#: components/pages/Purchases/index.tsx:30
+#: components/pages/Purchases/index.tsx:28
 msgid "{amount} tonnes were purchased for project {0}"
 msgstr ""

--- a/carbonmark/locale/en/messages.po
+++ b/carbonmark/locale/en/messages.po
@@ -13,37 +13,41 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: components/pages/errors/Custom404.tsx:13
 #: components/pages/errors/Custom404.tsx:14
 #: components/pages/errors/Custom404.tsx:15
-#: components/pages/errors/Custom404.tsx:16
-#: components/pages/errors/Custom404.tsx:23
+#: components/pages/errors/Custom404.tsx:22
 msgid "404 - Page Not Found"
 msgstr "404 - Page Not Found"
 
+#: components/pages/errors/Custom500.tsx:13
 #: components/pages/errors/Custom500.tsx:14
 #: components/pages/errors/Custom500.tsx:15
-#: components/pages/errors/Custom500.tsx:16
 msgid "500 - Server Error"
 msgstr "500 - Server Error"
 
-#: components/pages/errors/Custom500.tsx:23
+#: components/pages/errors/Custom500.tsx:22
 msgid "500 - Server error occurred"
 msgstr "500 - Server error occurred"
 
-#: components/Stats/index.tsx:65
+#: components/Stats/index.tsx:62
 msgid "Active listings:"
 msgstr "Active listings:"
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:151
-#: components/pages/Project/Purchase/PurchaseForm.tsx:184
+#: components/ProjectFilterModal/index.tsx:64
+msgid "Apply"
+msgstr "Apply"
+
+#: components/pages/Project/Purchase/PurchaseForm.tsx:152
+#: components/pages/Project/Purchase/PurchaseForm.tsx:185
 msgid "Available:"
 msgstr "Available:"
 
-#: components/pages/Projects/index.tsx:32
+#: components/pages/Projects/index.tsx:33
 msgid "Browse Carbon Projects | Carbonmark"
 msgstr "Browse Carbon Projects | Carbonmark"
 
-#: components/pages/Projects/index.tsx:33
+#: components/pages/Projects/index.tsx:34
 msgid "Browse our massive inventory of verified carbon offset projects. Buy, sell, or offset in a few clicks."
 msgstr "Browse our massive inventory of verified carbon offset projects. Buy, sell, or offset in a few clicks."
 
@@ -51,35 +55,47 @@ msgstr "Browse our massive inventory of verified carbon offset projects. Buy, se
 msgid "Built with 🌳 by <0>KlimaDAO</0>"
 msgstr "Built with 🌳 by <0>KlimaDAO</0>"
 
-#: components/pages/Resources/index.tsx:24
+#: components/pages/Resources/index.tsx:23
 msgid "CarbonMark News & Resources"
 msgstr "CarbonMark News & Resources"
 
-#: components/pages/Resources/index.tsx:23
+#: components/pages/Resources/index.tsx:22
 msgid "CarbonMark | Resources"
 msgstr "CarbonMark | Resources"
 
-#: components/pages/Home/index.tsx:18
+#: components/pages/Home/index.tsx:19
 msgid "Carbonmark | Universal Carbon Market"
 msgstr "Carbonmark | Universal Carbon Market"
 
-#: components/pages/Home/index.tsx:17
+#: components/pages/Home/index.tsx:18
 msgid "Carbonmark.com"
 msgstr "Carbonmark.com"
+
+#: components/ProjectFilterModal/index.tsx:56
+msgid "Category"
+msgstr "Category"
 
 #: components/shared/ChangeLanguageButton/index.tsx:48
 msgid "Change language"
 msgstr "Change language"
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:37
+#: components/ProjectFilterModal/index.tsx:68
+msgid "Clear Filters"
+msgstr "Clear Filters"
+
+#: components/pages/Project/Purchase/PurchaseForm.tsx:38
 msgid "Cost incl. {0}% fee"
 msgstr "Cost incl. {0}% fee"
+
+#: components/ProjectFilterModal/index.tsx:53
+msgid "Country"
+msgstr "Country"
 
 #: components/pages/Project/ProjectListing/index.tsx:58
 msgid "Created:"
 msgstr "Created:"
 
-#: components/pages/Project/index.tsx:132
+#: components/pages/Project/index.tsx:131
 msgid "Description"
 msgstr "Description"
 
@@ -87,11 +103,11 @@ msgstr "Description"
 msgid "Enter App"
 msgstr "Enter App"
 
-#: components/pages/Purchases/index.tsx:107
+#: components/pages/Purchases/index.tsx:105
 msgid "Final price"
 msgstr "Final price"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:153
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:154
 msgid "Handle should not contain any special characters"
 msgstr "Handle should not contain any special characters"
 
@@ -99,17 +115,17 @@ msgstr "Handle should not contain any special characters"
 msgid "Home"
 msgstr "Home"
 
-#: components/pages/Users/SellerConnected/index.tsx:178
+#: components/pages/Users/SellerConnected/index.tsx:173
 #: components/pages/Users/SellerUnconnected/index.tsx:50
 msgid "Listings"
 msgstr "Listings"
 
-#: components/pages/Portfolio/index.tsx:148
+#: components/pages/Portfolio/index.tsx:149
 msgid "Loading your data..."
 msgstr "Loading your data..."
 
 #: components/LoginCard/index.tsx:34
-#: components/pages/Project/Purchase/PurchaseForm.tsx:187
+#: components/pages/Project/Purchase/PurchaseForm.tsx:188
 msgid "Loading..."
 msgstr "Loading..."
 
@@ -137,22 +153,30 @@ msgstr "Login / Connect"
 msgid "Marketplace"
 msgstr "Marketplace"
 
-#: components/pages/Project/index.tsx:150
+#: components/pages/Project/index.tsx:149
 msgid "No listings found for this project."
 msgstr "No listings found for this project."
 
-#: components/Layout/AddressSection/index.tsx:20
+#: components/Layout/AddressSection/index.tsx:21
 msgid "Not Connected"
 msgstr "Not Connected"
 
-#: components/pages/Purchases/index.tsx:63
+#: components/pages/Purchases/index.tsx:61
 msgid "Payment Successful"
 msgstr "Payment Successful"
 
-#: components/pages/Portfolio/index.tsx:122
-#: components/pages/Users/SellerConnected/index.tsx:158
+#: components/pages/Portfolio/index.tsx:123
+#: components/pages/Users/SellerConnected/index.tsx:153
 msgid "Please refresh the page. There was an error updating your data: {e}."
 msgstr "Please refresh the page. There was an error updating your data: {e}."
+
+#: components/ProjectFilterModal/constants.tsx:8
+msgid "Price Highest"
+msgstr "Price Highest"
+
+#: components/ProjectFilterModal/constants.tsx:9
+msgid "Price Lowest"
+msgstr "Price Lowest"
 
 #: components/Footer/index.tsx:33
 #: components/shared/Navigation/index.tsx:64
@@ -160,16 +184,16 @@ msgstr "Please refresh the page. There was an error updating your data: {e}."
 msgid "Profile"
 msgstr "Profile"
 
-#: components/pages/Purchases/index.tsx:116
+#: components/pages/Purchases/index.tsx:114
 msgid "Project"
 msgstr "Project"
 
-#: components/pages/Projects/index.tsx:31
+#: components/pages/Projects/index.tsx:32
 msgid "Projects | Carbonmark"
 msgstr "Projects | Carbonmark"
 
-#: components/pages/Purchases/index.tsx:37
-#: components/pages/Purchases/index.tsx:38
+#: components/pages/Purchases/index.tsx:35
+#: components/pages/Purchases/index.tsx:36
 msgid "Purchase Receipt | Carbonmark"
 msgstr "Purchase Receipt | Carbonmark"
 
@@ -183,9 +207,13 @@ msgstr "Purchase {0} | Carbonmark"
 msgid "Quantity Available:"
 msgstr "Quantity Available:"
 
-#: components/pages/Purchases/index.tsx:98
+#: components/pages/Purchases/index.tsx:96
 msgid "Quantity purchased:"
 msgstr "Quantity purchased:"
+
+#: components/ProjectFilterModal/constants.tsx:10
+msgid "Recently Updated"
+msgstr "Recently Updated"
 
 #: components/Footer/index.tsx:36
 #: components/shared/Navigation/index.tsx:70
@@ -205,53 +233,57 @@ msgstr "Sell"
 msgid "Seller Listing"
 msgstr "Seller Listing"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:109
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:110
 msgid "Something went wrong. Please try again. {error}"
 msgstr "Something went wrong. Please try again. {error}"
 
-#: components/pages/errors/Custom404.tsx:26
+#: components/pages/errors/Custom404.tsx:25
 msgid "Sorry, looks like we sent you the wrong way."
 msgstr "Sorry, looks like we sent you the wrong way."
 
-#: components/pages/errors/Custom500.tsx:26
+#: components/pages/errors/Custom500.tsx:25
 msgid "Sorry, something went wrong."
 msgstr "Sorry, something went wrong."
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:164
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:165
 msgid "Sorry, this handle already exists"
 msgstr "Sorry, this handle already exists"
 
-#: components/pages/Portfolio/index.tsx:178
+#: components/pages/Portfolio/index.tsx:179
 msgid "Success. Go to your <0>Profile page</0> to see your new listing."
 msgstr "Success. Go to your <0>Profile page</0> to see your new listing."
 
-#: components/shared/InvalidNetworkModal/index.tsx:72
+#: components/shared/InvalidNetworkModal/index.tsx:74
 msgid "Switch to Polygon"
 msgstr "Switch to Polygon"
 
-#: components/pages/Purchases/index.tsx:74
+#: components/pages/Purchases/index.tsx:72
 msgid "Thank you for supporting the planet! See purchase details below."
 msgstr "Thank you for supporting the planet! See purchase details below."
 
-#: components/pages/Home/index.tsx:19
+#: components/pages/Home/index.tsx:20
 msgid "The open platform for digital carbon."
 msgstr "The open platform for digital carbon."
 
-#: components/pages/Users/SellerConnected/index.tsx:121
+#: components/pages/Users/SellerConnected/index.tsx:116
 msgid "There was an error getting your data: {error}"
 msgstr "There was an error getting your data: {error}"
 
-#: components/pages/Users/SellerConnected/index.tsx:84
+#: components/pages/Users/SellerConnected/index.tsx:79
 msgid "There was an error loading your assets. {e}"
 msgstr "There was an error loading your assets. {e}"
 
-#: components/shared/InvalidNetworkModal/index.tsx:68
+#: components/shared/InvalidNetworkModal/index.tsx:70
 msgid "This app only works on Polygon Mainnet."
 msgstr "This app only works on Polygon Mainnet."
 
 #: components/pages/Project/Purchase/index.tsx:208
 msgid "This offer no longer exists."
 msgstr "This offer no longer exists."
+
+#: components/Dropdown/index.tsx:72
+msgid "Toggle sort menu"
+msgstr "Toggle sort menu"
 
 #: components/Stats/index.tsx:55
 msgid "Tonnes listed:"
@@ -265,11 +297,11 @@ msgstr "Tonnes sold:"
 msgid "Updated:"
 msgstr "Updated:"
 
-#: components/pages/Resources/index.tsx:25
+#: components/pages/Resources/index.tsx:24
 msgid "Updates, guides and more from the CarbonMark team"
 msgstr "Updates, guides and more from the CarbonMark team"
 
-#: components/pages/Users/SellerConnected/index.tsx:232
+#: components/pages/Users/SellerConnected/index.tsx:227
 msgid "Updating your data..."
 msgstr "Updating your data..."
 
@@ -278,31 +310,43 @@ msgstr "Updating your data..."
 msgid "User Profile | Carbonmark"
 msgstr "User Profile | Carbonmark"
 
-#: components/pages/Users/index.tsx:47
+#: components/pages/Users/index.tsx:46
 msgid "View seller listings, carbon market activity and more."
 msgstr "View seller listings, carbon market activity and more."
 
-#: components/pages/Purchases/index.tsx:31
+#: components/pages/Purchases/index.tsx:29
 msgid "View the project details and other info for this purchase."
 msgstr "View the project details and other info for this purchase."
 
-#: components/pages/Purchases/index.tsx:67
+#: components/ProjectFilterModal/index.tsx:63
+msgid "Vintage"
+msgstr "Vintage"
+
+#: components/ProjectFilterModal/constants.tsx:11
+msgid "Vintage Newest"
+msgstr "Vintage Newest"
+
+#: components/ProjectFilterModal/constants.tsx:12
+msgid "Vintage Oldest"
+msgstr "Vintage Oldest"
+
+#: components/pages/Purchases/index.tsx:65
 msgid "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
 msgstr "We are still processing your successful purchase. Please visit this page again in a few minutes to see your receipt."
 
-#: components/pages/Portfolio/index.tsx:190
+#: components/pages/Portfolio/index.tsx:191
 msgid "We couldn't find any C3 tokens in your connected wallet :("
 msgstr "We couldn't find any C3 tokens in your connected wallet :("
 
-#: components/shared/InvalidNetworkModal/index.tsx:62
+#: components/shared/InvalidNetworkModal/index.tsx:64
 msgid "Wrong Network"
 msgstr "Wrong Network"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:103
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:104
 msgid "You chose to reject the transaction."
 msgstr "You chose to reject the transaction."
 
-#: components/Layout/AddressSection/index.tsx:16
+#: components/Layout/AddressSection/index.tsx:17
 msgid "Your Wallet Address:"
 msgstr "Your Wallet Address:"
 
@@ -335,11 +379,11 @@ msgid "activity.you"
 msgstr "You"
 
 #. Long sentence
-#: components/pages/Blog/Post/index.tsx:88
+#: components/pages/Blog/Post/index.tsx:85
 msgid "blog.disclaimer.description"
 msgstr "The information provided in this blog post pertaining to KlimaDAO (“KlimaDAO”), its crypto-assets, business assets, strategy, and operations, is for general informational purposes only and is not a formal offer to sell or a solicitation of an offer to buy any securities, options, futures, or other derivatives related to securities in any jurisdiction and its content is not prescribed by securities laws. Information contained in this blog post should not be relied upon as advice to buy or sell or hold such securities or as an offer to sell such securities. This blog post does not take into account nor does it provide any tax, legal or investment advice or opinion regarding the specific investment objectives or financial situation of any person. KlimaDAO and its agents, advisors, directors, officers, employees and shareholders make no representation or warranties, expressed or implied, as to the accuracy of such information and KlimaDAO expressly disclaims any and all liability that may be based on such information or errors or omissions thereof. KlimaDAO reserves the right to amend or replace the information contained herein, in part or entirely, at any time, and undertakes no obligation to provide the recipient with access to the amended information or to notify the recipient thereof. The information contained in this blog post supersedes any prior blog post or conversation concerning the same, similar or related information. Any information, representations or statements not contained herein shall not be relied upon for any purpose. Neither KlimaDAO nor any of its representatives shall have any liability whatsoever, under contract, tort, trust or otherwise, to you or any person resulting from the use of the information in this blog post by you or any of your representatives or for omissions from the information in this blog post. Additionally, KlimaDAO undertakes no obligation to comment on the expectations of, or statements made by, third parties in respect of the matters discussed in this blog post."
 
-#: components/pages/Blog/Post/index.tsx:85
+#: components/pages/Blog/Post/index.tsx:82
 msgid "blog.disclaimer.title"
 msgstr "Disclaimer:"
 
@@ -359,11 +403,11 @@ msgstr "or continue with"
 msgid "connect_modal.connecting"
 msgstr "Connecting..."
 
-#: lib/constants.ts:22
+#: lib/constants.ts:15
 msgid "connect_modal.error_message_default"
 msgstr "We had some trouble connecting. Please try again."
 
-#: lib/constants.ts:26
+#: lib/constants.ts:19
 msgid "connect_modal.error_message_refused"
 msgstr "User refused connection."
 
@@ -391,52 +435,56 @@ msgstr "Profile"
 msgid "portfolio.balances.title"
 msgstr "Balances"
 
-#: components/CreateListing/Form/index.tsx:163
+#: components/CreateListing/Form/index.tsx:165
 msgid "profile.addListing_modal.submit"
 msgstr "Create Listing"
 
-#: components/pages/Users/SellerConnected/index.tsx:205
+#: components/pages/Users/ProfileHeader/index.tsx:36
+msgid "profile.back_to_project_details"
+msgstr "Back to project details"
+
+#: components/pages/Users/SellerConnected/index.tsx:200
 msgid "profile.create_new_listing"
 msgstr "Create New Listing"
 
-#: components/pages/Users/ProfileHeader/index.tsx:36
+#: components/pages/Users/ProfileHeader/index.tsx:62
 msgid "profile.create_your_profile"
 msgstr "Create your profile on Carbonmark and start selling"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:142
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:143
 msgid "profile.editListing_modal.submit"
 msgstr "Update Listing"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:228
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:229
 msgid "profile.edit_modal.submit"
 msgstr "Save Changes"
 
-#: components/pages/Users/SellerConnected/index.tsx:263
+#: components/pages/Users/SellerConnected/index.tsx:258
 msgid "profile.edit_profile.title"
 msgstr "Your Profile"
 
-#: components/pages/Users/ProfileHeader/index.tsx:44
+#: components/pages/Users/ProfileHeader/index.tsx:70
 msgid "profile.edit_your_profile"
 msgstr "Edit your profile to add a description"
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:146
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:144
 msgid "profile.listing.delete.error"
 msgstr "Could not delete listing. Please try again."
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:161
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:159
 msgid "profile.listing.edit"
 msgstr "Edit"
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:189
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:187
 msgid "profile.listing.edit.delete_listing"
 msgstr "Delete Listing"
 
-#: components/pages/Users/SellerConnected/index.tsx:190
+#: components/pages/Users/SellerConnected/index.tsx:185
 #: components/pages/Users/SellerUnconnected/index.tsx:56
 msgid "profile.listings.empty_state"
 msgstr "No active listings to show."
 
-#: components/CreateListing/index.tsx:120
+#: components/CreateListing/index.tsx:121
 msgid "profile.listings_modal.title"
 msgstr "Create a Listing"
 
@@ -468,7 +516,7 @@ msgstr "Other Nature-Based"
 msgid "project.category.renewable_energy"
 msgstr "Renewable Energy"
 
-#: components/pages/Project/index.tsx:99
+#: components/pages/Project/index.tsx:98
 msgid "project.single.best_price"
 msgstr "Best Price"
 
@@ -476,11 +524,11 @@ msgstr "Best Price"
 msgid "project.single.button.back_to_project"
 msgstr "Back to Project"
 
-#: components/pages/Purchases/index.tsx:50
+#: components/pages/Purchases/index.tsx:48
 msgid "project.single.button.back_to_project_details"
 msgstr "Back to Project Details"
 
-#: components/pages/Project/index.tsx:57
+#: components/pages/Project/index.tsx:56
 msgid "project.single.button.back_to_projects"
 msgstr "Back to Projects"
 
@@ -488,7 +536,7 @@ msgstr "Back to Projects"
 msgid "project.single.header.seller"
 msgstr "Seller:"
 
-#: components/pages/Project/index.tsx:106
+#: components/pages/Project/index.tsx:105
 msgid "project.single.methodology"
 msgstr "Methodology:"
 
@@ -500,43 +548,43 @@ msgstr "for"
 msgid "props.transaction.conjunction.at"
 msgstr "at"
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:210
+#: components/pages/Project/Purchase/PurchaseForm.tsx:211
 msgid "purchase.button.continue"
 msgstr "Continue"
 
-#: components/pages/Purchases/index.tsx:131
+#: components/pages/Purchases/index.tsx:129
 msgid "purchase.button.view_assets"
 msgstr "View Your Assets"
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:144
+#: components/pages/Project/Purchase/PurchaseForm.tsx:145
 msgid "purchase.input.amount.label"
 msgstr "How many tonnes of carbon do you want to buy?"
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:137
+#: components/pages/Project/Purchase/PurchaseForm.tsx:138
 msgid "purchase.input.amount.maxAmount"
 msgstr "You exceeded the available amount of tonnes"
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:130
+#: components/pages/Project/Purchase/PurchaseForm.tsx:131
 msgid "purchase.input.amount.minimum"
 msgstr "The minimum amount to buy is 1 Tonne"
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:112
+#: components/pages/Project/Purchase/PurchaseForm.tsx:113
 msgid "purchase.input.amount.placeholder"
 msgstr "Tonnes"
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:123
+#: components/pages/Project/Purchase/PurchaseForm.tsx:124
 msgid "purchase.input.amount.required"
 msgstr "Amount is required"
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:167
+#: components/pages/Project/Purchase/PurchaseForm.tsx:168
 msgid "purchase.input.price.maxAmount"
 msgstr "You exceeded your available amount of tokens"
 
-#: components/pages/Project/Purchase/PurchaseForm.tsx:160
+#: components/pages/Project/Purchase/PurchaseForm.tsx:161
 msgid "purchase.input.price.required"
 msgstr "Price is required"
 
-#: components/pages/Project/Purchase/index.tsx:84
+#: components/pages/Project/Purchase/index.tsx:83
 msgid "purchase.loading.allowance.error"
 msgstr "something went wrong loading the allowance"
 
@@ -552,27 +600,27 @@ msgstr "Confirm Purchase"
 msgid "purchase.transaction.modal.title.processing"
 msgstr "Processing Purchase"
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:24
+#: components/pages/Resources/ResourcesFilters/index.tsx:22
 msgid "resources.form.categories.header"
 msgstr "Categories"
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:27
+#: components/pages/Resources/ResourcesFilters/index.tsx:25
 msgid "resources.form.categories.subheader"
 msgstr "Select one or more"
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:53
+#: components/pages/Resources/ResourcesFilters/index.tsx:51
 msgid "resources.form.filters.clear_all"
 msgstr "Clear All"
 
-#: components/pages/Resources/ResourcesList/index.tsx:177
+#: components/pages/Resources/ResourcesList/index.tsx:170
 msgid "resources.form.input.search.label"
 msgstr "Search"
 
-#: components/pages/Resources/ResourcesList/index.tsx:168
+#: components/pages/Resources/ResourcesList/index.tsx:161
 msgid "resources.form.input.search.placeholder"
 msgstr "Search..."
 
-#: components/pages/Resources/ResourcesList/index.tsx:201
+#: components/pages/Resources/ResourcesList/index.tsx:194
 msgid "resources.form.input.sort_by.label"
 msgstr "Sort by"
 
@@ -580,7 +628,7 @@ msgstr "Sort by"
 msgid "resources.form.input.sort_by.select"
 msgstr "Select"
 
-#: components/pages/Resources/ResourcesFilters/index.tsx:41
+#: components/pages/Resources/ResourcesFilters/index.tsx:39
 msgid "resources.form.sub_topics.header"
 msgstr "Sub-topics"
 
@@ -649,43 +697,43 @@ msgstr "Oldest First"
 msgid "resources.list.sort_by.z-a"
 msgstr "Z-A"
 
-#: components/pages/Resources/ResourcesList/index.tsx:302
+#: components/pages/Resources/ResourcesList/index.tsx:295
 msgid "resources.mobile_modal.button.show_results"
 msgstr "Show Results"
 
-#: components/pages/Resources/ResourcesList/index.tsx:275
+#: components/pages/Resources/ResourcesList/index.tsx:268
 msgid "resources.mobile_modal.title"
 msgstr "Sort By"
 
-#: components/pages/Resources/index.tsx:37
+#: components/pages/Resources/index.tsx:36
 msgid "resources.page.header.subline"
 msgstr "Updates and thought leadership from the CarbonMark team."
 
-#: components/pages/Resources/index.tsx:34
+#: components/pages/Resources/index.tsx:33
 msgid "resources.page.header.title"
 msgstr "Featured Articles"
 
-#: components/pages/Resources/ResourcesList/index.tsx:159
+#: components/pages/Resources/ResourcesList/index.tsx:152
 msgid "resources.page.list.header"
 msgstr "Explore All"
 
-#: components/pages/Resources/ResourcesList/index.tsx:240
+#: components/pages/Resources/ResourcesList/index.tsx:233
 msgid "resources.page.list.no_search_results.title"
 msgstr "Sorry. We couldn't find any matching results."
 
-#: components/pages/Resources/ResourcesList/index.tsx:232
+#: components/pages/Resources/ResourcesList/index.tsx:225
 msgid "resources.page.list.on_fetch_error"
 msgstr "Sorry! Something went wrong."
 
-#: components/pages/Resources/ResourcesList/index.tsx:253
+#: components/pages/Resources/ResourcesList/index.tsx:246
 msgid "resources.page.list.search_submit.no_filter_results"
 msgstr "Please use a different filter combination."
 
-#: components/pages/Resources/ResourcesList/index.tsx:246
+#: components/pages/Resources/ResourcesList/index.tsx:239
 msgid "resources.page.list.search_submit.no_search_results"
 msgstr "Check your search for typos or try a different search term."
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:169
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:167
 msgid "seller.edit_listing.title"
 msgstr "Edit Listing"
 
@@ -693,16 +741,16 @@ msgstr "Edit Listing"
 msgid "seller.listing.buy"
 msgstr "Buy"
 
-#: components/pages/Users/Listing/index.tsx:39
+#: components/pages/Users/Listing/index.tsx:36
 msgid "seller.listing.quantity_available"
 msgstr "Quantity Available:"
 
-#: components/Transaction/Approve.tsx:112
+#: components/Transaction/Approve.tsx:109
 msgid "shared.approve"
 msgstr "Approve"
 
 #: components/pages/Project/ProjectListing/index.tsx:70
-#: components/pages/Project/Purchase/PurchaseForm.tsx:196
+#: components/pages/Project/Purchase/PurchaseForm.tsx:197
 #: components/pages/Users/SellerUnconnected/index.tsx:73
 msgid "shared.connect_to_buy"
 msgstr "Sign In / Connect To Buy"
@@ -711,16 +759,16 @@ msgstr "Sign In / Connect To Buy"
 msgid "shared.enter_app"
 msgstr "Enter App"
 
-#: components/pages/Blog/Post/index.tsx:71
+#: components/pages/Blog/Post/index.tsx:68
 msgid "shared.resourcecenter"
 msgstr "Resource Center"
 
-#: components/pages/Resources/ResourcesList/index.tsx:207
+#: components/pages/Resources/ResourcesList/index.tsx:200
 msgid "shared.resources.sort_by.header"
 msgstr "Sort by:"
 
-#: components/CreateListing/index.tsx:145
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:216
+#: components/CreateListing/index.tsx:146
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:214
 msgid "tonnes.long"
 msgstr "tonnes"
 
@@ -728,11 +776,11 @@ msgstr "tonnes"
 msgid "tonnes.short"
 msgstr "t"
 
-#: components/CreateListing/index.tsx:154
+#: components/CreateListing/index.tsx:155
 msgid "transaction.create_listing.approval_description"
 msgstr "You are about to transfer ownership of this asset from your wallet to the KlimaDAO  You can remove your listing at any time until it has been sold."
 
-#: components/pages/Users/SellerConnected/ListingEditable.tsx:225
+#: components/pages/Users/SellerConnected/ListingEditable.tsx:223
 msgid "transaction.edit_listing.approval_description"
 msgstr "You are about to transfer ownership of this asset from your wallet to the KlimaDAO Carbonmark. You can remove your listing at any time until it has been sold."
 
@@ -756,177 +804,177 @@ msgstr "Please click 'confirm' in your wallet to continue."
 msgid "transaction.status.user_rejected"
 msgstr "You chose to reject the transaction"
 
-#: components/Transaction/Approve.tsx:65
+#: components/Transaction/Approve.tsx:62
 msgid "transaction_modal.approve.amount"
 msgstr "Confirm amount"
 
-#: components/Transaction/Approve.tsx:55
+#: components/Transaction/Approve.tsx:52
 msgid "transaction_modal.approve.contract_address"
 msgstr "Contract address"
 
-#: components/Transaction/Approve.tsx:81
+#: components/Transaction/Approve.tsx:78
 msgid "transaction_modal.approve.price"
 msgstr "Confirm price per tonne"
 
-#: components/Transaction/Approve.tsx:47
+#: components/Transaction/Approve.tsx:44
 msgid "transaction_modal.approve.title"
 msgstr "Please confirm the transaction"
 
-#: components/Transaction/index.tsx:88
+#: components/Transaction/index.tsx:87
 msgid "transaction_modal.button.go_back"
 msgstr "Go back"
 
-#: components/Transaction/Submit.tsx:117
+#: components/Transaction/Submit.tsx:115
 msgid "transaction_modal.close"
 msgstr "Close"
 
-#: components/Transaction/Approve.tsx:120
+#: components/Transaction/Approve.tsx:117
 msgid "transaction_modal.next"
 msgstr "Next"
 
-#: components/Transaction/Submit.tsx:64
+#: components/Transaction/Submit.tsx:62
 msgid "transaction_modal.submit.amount"
 msgstr "Submit amount"
 
-#: components/Transaction/Submit.tsx:109
+#: components/Transaction/Submit.tsx:107
 msgid "transaction_modal.submit.button"
 msgstr "Submit"
 
-#: components/Transaction/Submit.tsx:54
+#: components/Transaction/Submit.tsx:52
 msgid "transaction_modal.submit.contract_address"
 msgstr "Contract address"
 
-#: components/Transaction/Submit.tsx:78
+#: components/Transaction/Submit.tsx:76
 msgid "transaction_modal.submit.price"
 msgstr "Submit price per tonne"
 
-#: components/Transaction/Submit.tsx:46
+#: components/Transaction/Submit.tsx:44
 msgid "transaction_modal.submit.title"
 msgstr "Please submit the transaction"
 
-#: components/Transaction/index.tsx:48
+#: components/Transaction/index.tsx:47
 msgid "transaction_modal.view.approve.title"
 msgstr "1. Approve"
 
-#: components/Transaction/index.tsx:58
+#: components/Transaction/index.tsx:57
 msgid "transaction_modal.view.submit.title"
 msgstr "2. Submit"
 
-#: components/Activities/index.tsx:31
+#: components/Activities/index.tsx:32
 msgid "user.activities.empty_state"
 msgstr "No activity to show"
 
-#: components/Activities/index.tsx:26
+#: components/Activities/index.tsx:27
 msgid "user.activities.title"
 msgstr "Activities"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:133
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:134
 msgid "user.edit.edit.input.price.label"
 msgstr "Price"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:109
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:110
 msgid "user.edit.form.edit.price.placeholder"
 msgstr "USDC per ton"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:97
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:98
 msgid "user.edit.form.edit.quantity.label"
 msgstr "Quantity"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:211
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:212
 msgid "user.edit.form.input.description.label"
 msgstr "About"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:205
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:206
 msgid "user.edit.form.input.description.placeholder"
 msgstr "Description"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:170
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:171
 msgid "user.edit.form.input.handle.label"
 msgstr "Handle (not changeable later! Choose wisely)"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:158
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:159
 msgid "user.edit.form.input.handle.no_polygon_address"
 msgstr "Handle should not be an address"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:135
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:136
 msgid "user.edit.form.input.handle.placeholder"
 msgstr "Your unique handle"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:146
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:147
 msgid "user.edit.form.input.handle.required"
 msgstr "Handle is required"
 
-#: components/CreateListing/Form/index.tsx:154
+#: components/CreateListing/Form/index.tsx:156
 msgid "user.edit.form.input.singleUnitPrice.label"
 msgstr "Single Unit Price"
 
-#: components/CreateListing/Form/index.tsx:125
+#: components/CreateListing/Form/index.tsx:127
 msgid "user.edit.form.input.singleUnitPrice.placeholder"
 msgstr "USDC per ton"
 
-#: components/CreateListing/Form/index.tsx:113
+#: components/CreateListing/Form/index.tsx:115
 msgid "user.edit.form.input.totalAmountToSell.label"
 msgstr "Total Amount"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:195
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:196
 msgid "user.edit.form.input.username.label"
 msgstr "Display Name"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:180
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:181
 msgid "user.edit.form.input.username.placeholder"
 msgstr "Your display name"
 
-#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:188
+#: components/pages/Users/SellerConnected/Forms/EditProfile.tsx:189
 msgid "user.edit.form.input.username.required"
 msgstr "Display Name is required"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:90
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:91
 msgid "user.listing.edit.input.quantity.maxAmount"
 msgstr "You exceeded your available quantity"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:83
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:84
 msgid "user.listing.edit.input.quantity.minimum"
 msgstr "The minimum quantity to sell is 1 Tonne"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:68
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:69
 msgid "user.listing.edit.input.quantity.placeholder"
 msgstr "How many do you want to sell"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:76
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:77
 msgid "user.listing.edit.input.quantity.required"
 msgstr "Quantity is required"
 
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:48
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:49
 msgid "user.listing.edit.project.label"
 msgstr "Project"
 
-#: components/CreateListing/Form/index.tsx:60
+#: components/CreateListing/Form/index.tsx:62
 msgid "user.listing.form.input.select_project.label"
 msgstr "Select Project:"
 
-#: components/CreateListing/Form/index.tsx:145
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:124
+#: components/CreateListing/Form/index.tsx:147
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:125
 msgid "user.listing.form.input.singleUnitPrice.minimum"
 msgstr "The minimum price per tonne is {0}"
 
-#: components/CreateListing/Form/index.tsx:133
-#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:117
+#: components/CreateListing/Form/index.tsx:135
+#: components/pages/Users/SellerConnected/Forms/EditListing.tsx:118
 msgid "user.listing.form.input.singleUnitPrice.required"
 msgstr "Single Price is required"
 
-#: components/CreateListing/Form/index.tsx:106
+#: components/CreateListing/Form/index.tsx:108
 msgid "user.listing.form.input.totalAmountToSell.maxAmount"
 msgstr "You exceeded your available amount"
 
-#: components/CreateListing/Form/index.tsx:99
+#: components/CreateListing/Form/index.tsx:101
 msgid "user.listing.form.input.totalAmountToSell.minimum"
 msgstr "The minimum amount to sell is 1 Tonne"
 
-#: components/CreateListing/Form/index.tsx:84
+#: components/CreateListing/Form/index.tsx:86
 msgid "user.listing.form.input.totalAmountToSell.placeholder"
 msgstr "How many do you want to sell"
 
-#: components/CreateListing/Form/index.tsx:92
+#: components/CreateListing/Form/index.tsx:94
 msgid "user.listing.form.input.totalAmountToSell.required"
 msgstr "Total Amount to Sell is required"
 
@@ -946,20 +994,20 @@ msgstr "Data for this seller"
 msgid "user.stats.title"
 msgstr "Stats"
 
-#: components/pages/Portfolio/index.tsx:202
-#: components/pages/Users/SellerConnected/index.tsx:250
+#: components/pages/Portfolio/index.tsx:203
+#: components/pages/Users/SellerConnected/index.tsx:245
 msgid "user.stats.your_seller_data.description"
 msgstr "Your seller data"
 
+#: components/pages/Project/index.tsx:47
 #: components/pages/Project/index.tsx:48
-#: components/pages/Project/index.tsx:49
 msgid "{0} | Carbonmark"
 msgstr "{0} | Carbonmark"
 
-#: components/pages/Users/index.tsx:41
+#: components/pages/Users/index.tsx:40
 msgid "{0} | Profile | Carbonmark"
 msgstr "{0} | Profile | Carbonmark"
 
-#: components/pages/Purchases/index.tsx:30
+#: components/pages/Purchases/index.tsx:28
 msgid "{amount} tonnes were purchased for project {0}"
 msgstr "{amount} tonnes were purchased for project {0}"


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Adds a "Back to project details" button to the user profile. I've added some code to store the previous and current route so we can determine to show/hide the button based on if the user navigated from another route or not. 

I'm not sure the checks are totally necessary to be honest, but an example - if a user loads a user profile directly in the browser we would show a button that says "back to project details" and when clicked does nothing?

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #199

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|
 -->
## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
