### PR TITLE
Set default config to mainnet

### DIFF
--- a/carbonmark/lib/constants.ts
+++ b/carbonmark/lib/constants.ts
@@ -53,7 +53,7 @@ export const config = {
   },
 } as const;
 
-const DEFAULT_NETWORK = config.networks[ENVIRONMENT];
+export const DEFAULT_NETWORK = config.networks[ENVIRONMENT];
 
 export const urls = {
   api: {

--- a/carbonmark/lib/networkAware/getAddress.ts
+++ b/carbonmark/lib/networkAware/getAddress.ts
@@ -1,10 +1,10 @@
 import { addresses } from "@klimadao/lib/constants";
-import { config } from "lib/constants";
+import { DEFAULT_NETWORK } from "lib/constants";
 
-/** Grab an address based on the given `network` parameter, fallback to config.defaultNetwork */
+/** Grab an address based on the given `network` parameter, fallback to DEFAULT_NETWORK */
 export const getAddress = (
   name: keyof typeof addresses.mainnet,
   network?: "testnet" | "mainnet"
 ): string => {
-  return addresses[network ?? config.defaultNetwork][name];
+  return addresses[network ?? DEFAULT_NETWORK][name];
 };

--- a/carbonmark/lib/networkAware/getAllowance.ts
+++ b/carbonmark/lib/networkAware/getAllowance.ts
@@ -1,9 +1,9 @@
 import { getAllowance as IGetAllowance } from "@klimadao/lib/utils";
-import { config } from "lib/constants";
+import { DEFAULT_NETWORK } from "lib/constants";
 
-/** Fetch an allowance based on the given `network` parameter, fallback to config.defaultNetwork */
+/** Fetch an allowance based on the given `network` parameter, fallback to DEFAULT_NETWORK */
 export const getAllowance = (params: Parameters<typeof IGetAllowance>[0]) => {
-  const { network = config.defaultNetwork } = params;
+  const { network = DEFAULT_NETWORK } = params;
   return IGetAllowance({
     ...params,
     network,

--- a/carbonmark/lib/networkAware/getContract.ts
+++ b/carbonmark/lib/networkAware/getContract.ts
@@ -1,11 +1,11 @@
 import { getContract as IGetContract } from "@klimadao/lib/utils";
 import { Contract } from "ethers";
-import { config } from "lib/constants";
+import { DEFAULT_NETWORK } from "lib/constants";
 
-/** Grab a contract based on the given `network` parameter, fallback to config.defaultNetwork */
+/** Grab a contract based on the given `network` parameter, fallback to DEFAULT_NETWORK */
 export const getContract = (
   params: Parameters<typeof IGetContract>[0]
 ): Contract => {
-  const { network = config.defaultNetwork } = params;
+  const { network = DEFAULT_NETWORK } = params;
   return IGetContract({ ...params, network });
 };

--- a/carbonmark/lib/networkAware/getStaticProvider.ts
+++ b/carbonmark/lib/networkAware/getStaticProvider.ts
@@ -1,13 +1,12 @@
 import { getStaticProvider as IGetStaticProvider } from "@klimadao/lib/utils";
 import { providers } from "ethers";
-import { config } from "lib/constants";
+import { DEFAULT_NETWORK } from "lib/constants";
 
-/** Get a static provider based on the given `chain` parameter, fallback to config.defaultNetwork */
+/** Get a static provider based on the given `chain` parameter, fallback to DEFAULT_NETWORK */
 export const getStaticProvider = (
   params?: Parameters<typeof IGetStaticProvider>[0]
 ): providers.JsonRpcProvider => {
-  const defaultChain =
-    config.defaultNetwork === "testnet" ? "mumbai" : "polygon";
+  const defaultChain = DEFAULT_NETWORK === "testnet" ? "mumbai" : "polygon";
   const chain = params?.chain || defaultChain;
   return IGetStaticProvider({ ...params, chain });
 };

--- a/carbonmark/lib/networkAware/getTokenDecimals.ts
+++ b/carbonmark/lib/networkAware/getTokenDecimals.ts
@@ -1,10 +1,10 @@
 import { getTokenDecimals as IGetTokenDecimals } from "@klimadao/lib/utils";
-import { config } from "lib/constants";
+import { DEFAULT_NETWORK } from "lib/constants";
 
-/** Get decimals based on the given `network` parameter, fallback to config.defaultNetwork */
+/** Get decimals based on the given `network` parameter, fallback to DEFAULT_NETWORK */
 export const getTokenDecimals = (
   tkn: string,
   network?: "testnet" | "mainnet"
 ): 9 | 6 | 18 => {
-  return IGetTokenDecimals(tkn, network ?? config.defaultNetwork);
+  return IGetTokenDecimals(tkn, network ?? DEFAULT_NETWORK);
 };


### PR DESCRIPTION
## Description

This PR sets the default config for carbonmark to mainnet.

Please check if:
- more URLs needs to be changed for the API endpoints?
- The InvalidNetwork Modal is triggered when still on testnet?


## Related Ticket

Closes https://github.com/Atmosfearful/bezos-frontend/issues/15


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
