### PR TITLE
Emc/with skeleton wrapper component

### DIFF
--- a/carbonmark/components/Accordion/styles.ts
+++ b/carbonmark/components/Accordion/styles.ts
@@ -3,7 +3,6 @@ import * as typography from "@klimadao/lib/theme/typography";
 
 export const main = css`
   width: 100%;
-  padding: 0 0.4rem;
   border-bottom: 1px solid var(--surface-02);
 
   .content {

--- a/carbonmark/hocs/WithSkeleton/index.tsx
+++ b/carbonmark/hocs/WithSkeleton/index.tsx
@@ -1,37 +1,44 @@
 import { Skeleton } from "@mui/material";
-import { FC } from "react";
+import { FC, PropsWithChildren } from "react";
 import * as styles from "./styles";
 
-type WithSkeletonProps<T> = T & {
-  loading?: boolean;
-};
+type WithSkeletonDecoratorProps<T> = T & WithSkeletonProps;
 
-/**
- * Using the React Skeleton MUI component to automatically add a loading skeleton to a wrapped component
- * https://mui.com/material-ui/react-skeleton/
- * HOC pattern shamelessly ripped and customized from https://react-typescript-cheatsheet.netlify.app/docs/hoc/full_example
- */
-export function withSkeleton<T>(WrappedComponent: React.ComponentType<T>) {
+/** A decorator version of WithSkeleton */
+export function withSkeleton<T>(Component: React.ComponentType<T>) {
   // Maintain the previous display name
-  const displayName =
-    WrappedComponent.displayName ?? WrappedComponent.name ?? "Component";
+  const displayName = Component.displayName ?? Component.name ?? "Component";
 
   /** Create out wrapped skeleton component */
-  const ComponentWithSkeleton: FC<WithSkeletonProps<T>> = (props) =>
-    props.loading ? (
-      <Skeleton
-        variant="rounded"
-        width="100%"
-        className={styles.skeletonStyles}
-      >
-        <WrappedComponent {...props} />
-      </Skeleton>
-    ) : (
-      <WrappedComponent {...props} />
-    );
+  const ComponentWithSkeleton: FC<WithSkeletonDecoratorProps<T>> = (props) => (
+    <WithSkeleton>
+      <Component {...props} />
+    </WithSkeleton>
+  );
 
   /** Add another display name for the wrapped version */
   ComponentWithSkeleton.displayName = `withSkeleton(${displayName})`;
 
   return ComponentWithSkeleton;
 }
+
+type WithSkeletonProps = {
+  loading?: boolean;
+};
+
+/**
+ *  Using the React Skeleton MUI component to automatically add a loading skeleton to a wrapped component
+ * https://mui.com/material-ui/react-skeleton/
+ * HOC pattern shamelessly ripped and customized from https://react-typescript-cheatsheet.netlify.app/docs/hoc/full_example
+ */
+export const WithSkeleton: FC<WithSkeletonProps & PropsWithChildren> = (
+  props
+) => {
+  return props.loading ? (
+    <Skeleton variant="rounded" width="100%" className={styles.skeletonStyles}>
+      {props.children}
+    </Skeleton>
+  ) : (
+    <>{props.children}</>
+  );
+};


### PR DESCRIPTION
## Description

Provide both a `withSkeleton` decorator and a `<WithSkeleton>` wrapper component to allow granular use of the Skeleton component.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
