### PR TITLE
no hover button primary

### DIFF
--- a/carbonmark/components/Buttons/styles.ts
+++ b/carbonmark/components/Buttons/styles.ts
@@ -9,7 +9,7 @@ export const buttonPrimary = css`
   &,
   &:hover:not(:disabled),
   &:visited {
-    color: var(--surface-02); /* same in darkmode */
+    color: white; /* same in darkmode. same as not hovered. keep here to override hover state in lib */
   }
 
   &.gray {


### PR DESCRIPTION
## Description
hover state is same as unhovered state. left it in there to over ride the style in lib and left a comment to explain the double white color.
<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #270 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
