### PR TITLE
Update input hover border colors to match carbonmark

### DIFF
--- a/carbonmark/components/shared/Form/InputField/styles.ts
+++ b/carbonmark/components/shared/Form/InputField/styles.ts
@@ -41,7 +41,7 @@ export const baseStyles = css`
 
   &:focus,
   &:hover {
-    border-color: var(--klima-green);
+    border-color: var(--bright-blue);
   }
 
   &:disabled {

--- a/carbonmark/components/shared/Form/TextareaField/styles.ts
+++ b/carbonmark/components/shared/Form/TextareaField/styles.ts
@@ -30,7 +30,7 @@ export const baseStyles = css`
 
   &:focus,
   &:hover {
-    border-color: var(--klima-green);
+    border-color: var(--bright-blue);
   }
 
   &:disabled {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dev-cms": "cd ./cms && npm run start",
     "dev-carbonmark": "concurrently --kill-others-on-fail \"npm:dev-lib\" \"npm run dev --workspace=carbonmark\"",
     "deploy-cms": "cd ./cms && npm run deploy",
+    "lint-all": "npm run lint --workspaces",
     "format-all": "prettier --write ./",
     "extract-strings": "npm run -w site lingui:extract && npm run -w app lingui:extract && npm run -w carbonmark lingui:extract",
     "compile-strings": "npm run extract-strings && npm run -w site lingui:compile && npm run -w app lingui:compile && npm run -w carbonmark lingui:compile",


### PR DESCRIPTION
## Description

Updated border hover colors on input and textarea

## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/7104689/222927109-dae67b04-b31c-4f44-a662-676b1bacb4bf.png)|![image](https://user-images.githubusercontent.com/7104689/222927087-d506e313-7bf4-4818-b846-e561ec697bd5.png)|


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
