### PR TITLE
fix default sort on ProjectFilterModal

### DIFF
--- a/carbonmark/components/Dropdown/index.tsx
+++ b/carbonmark/components/Dropdown/index.tsx
@@ -7,7 +7,7 @@ import { Control, FieldValues, Path, useController } from "react-hook-form";
 import * as styles from "./styles";
 
 type Props<V, T extends FieldValues> = {
-  initial?: string;
+  initial?: V;
   options: Option<V>[];
   name: Path<T>;
   control: Control<T>;

--- a/carbonmark/components/ProjectFilterModal/index.tsx
+++ b/carbonmark/components/ProjectFilterModal/index.tsx
@@ -95,11 +95,14 @@ export const ProjectFilterModal: FC<ProjectFilterModalProps> = (props) => {
     props.onToggleModal?.();
   };
 
+  const initialSort = router.query.sort ? String(router.query.sort) : undefined;
+
   return (
     <Modal {...props} title="Filter Results" className={styles.main}>
       <form onSubmit={handleSubmit(onSubmit)}>
         <Dropdown
           name="sort"
+          initial={initialSort ?? "recently-updated"}
           className="dropdown"
           aria-label={t`Toggle sort menu`}
           renderLabel={(selected) => `Sort By: ${selected?.label}`}


### PR DESCRIPTION
## Description

Ensures that the sort query param is used initially for the dropdown

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

May or may not resolve #304 

<!-- If there are UI changes, please include a before and after screenshot in the following template:


-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
