### PR TITLE
Button CTA needs to be white

### DIFF
--- a/carbonmark/components/pages/Resources/ResourcesFilters/index.tsx
+++ b/carbonmark/components/pages/Resources/ResourcesFilters/index.tsx
@@ -38,7 +38,6 @@ export const ResourcesFilters: FC<Props> = (props) => {
         icon={<ClearIcon />}
         label={<Trans id="resources.form.filters.clear_all">Clear All</Trans>}
         onClick={props.onResetFilters}
-        className={styles.clearAllButton}
       />
     </div>
   );

--- a/carbonmark/components/pages/Resources/ResourcesFilters/styles.ts
+++ b/carbonmark/components/pages/Resources/ResourcesFilters/styles.ts
@@ -27,8 +27,3 @@ export const filtersCheckboxGroup = css`
   gap: 1.2rem;
   margin-bottom: 1.6rem;
 `;
-
-export const clearAllButton = css`
-  background-color: var(--surface-01);
-  color: var(--font-01) !important;
-`;


### PR DESCRIPTION
## Description
- [x] On the resources page, the CLEAR ALL button CTA needs to be white.

Resolves #310 

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
