### PR TITLE
fix: partners image large desktop, fix circle overlapping text

### DIFF
--- a/carbonmark/components/pages/Home/styles.ts
+++ b/carbonmark/components/pages/Home/styles.ts
@@ -110,7 +110,13 @@ export const partnersSection = css`
   ${breakpoints.desktop} {
     padding: 7.6rem 0rem 11rem !important;
     & img {
-      object-position: 27%;
+      object-position: center;
+    }
+  }
+
+  ${breakpoints.desktopLarge} {
+    & img {
+      object-position: center 28%;
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Fixes an issue on large desktop where the circle overlaps the partner logos.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
