### PR TITLE
fix: move best-price class up

### DIFF
--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -110,16 +110,18 @@ export const Project: NextPage<Props> = (props) => {
         </div>
 
         <div className={styles.meta}>
-          {bestPrice && (
-            <div className="best-price">
-              <Text t="h5" className="best-price-badge">
-                {formatToPrice(bestPrice)}
-              </Text>
-              <Text t="h5" color="lighter">
-                <Trans>Best Price</Trans>
-              </Text>
-            </div>
-          )}
+          <div className="best-price">
+            {bestPrice && (
+              <>
+                <Text t="h5" className="best-price-badge">
+                  {formatToPrice(bestPrice)}
+                </Text>
+                <Text t="h5" color="lighter">
+                  <Trans>Best Price</Trans>
+                </Text>
+              </>
+            )}
+          </div>
 
           <div className="methodology">
             <Text t="h5" color="lighter">


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Methodology text is shifting to the left of the page when there is no best price data.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #322 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
