### PR TITLE
fix: step 2 text, footer link & icon hover state

### DIFF
--- a/carbonmark/components/pages/Home/index.tsx
+++ b/carbonmark/components/pages/Home/index.tsx
@@ -72,13 +72,9 @@ export const Home: NextPage<Props> = (props) => {
           alt="Carbonmark Hero"
           src="/hero-sm.jpeg"
         />
-        <Image
-          fill
-          data-mobile-only
-          alt="Circle Tree"
-          src="/circle-tree.png"
-          className="circle-tree"
-        />
+        <div data-mobile-only className="circle-tree">
+          <Image fill alt="Circle Tree" src="/circle-tree.png" />
+        </div>
         <Navigation transparent activePage="Home" />
         <div className="stack">
           <Text t="h1" as="h1">

--- a/carbonmark/components/pages/Home/styles.ts
+++ b/carbonmark/components/pages/Home/styles.ts
@@ -27,12 +27,17 @@ export const hero = css`
     z-index: 1;
     object-fit: cover;
     object-position: -0.25rem 1rem;
+  }
 
-    &.circle-tree {
+  & .circle-tree {
+    position: absolute;
+    top: 5.5rem;
+    width: 8rem;
+    height: 8rem;
+    right: -2rem;
+
+    & img {
       object-fit: contain;
-      top: 6rem !important;
-      right: -2rem !important;
-      height: 8rem !important;
       object-position: top right;
     }
   }


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Addresses the following points in #321:

2. Change text from "Create profile", not "Create a profile"
3. KlimaDAO link in footer now links to [www.klimadao.finance](https://www.klimadao.finance/)
4. Clicking on the KlimaDAO logo now links to [www.klimadao.finance](https://www.klimadao.finance/)

- Fixes an issue on mobile where the circle tree width isn't set and causes a weird sizing issue. 

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #321

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
