### PR TITLE
304 - Add a custom BigNumber sort for projects

### DIFF
--- a/carbonmark/components/ProjectFilterModal/constants.tsx
+++ b/carbonmark/components/ProjectFilterModal/constants.tsx
@@ -1,6 +1,7 @@
 import { t } from "@lingui/macro";
 import { CheckboxOption } from "components/CheckboxGroup/CheckboxGroup.types";
 import { Text } from "components/Text";
+import { BigNumber } from "ethers";
 import { categoryNames, getCategoryInfo } from "lib/getCategoryInfo";
 import { Project } from "lib/types/carbonmark";
 import { sortBy } from "lib/utils/array.utils";
@@ -15,10 +16,15 @@ export const PROJECT_SORT_OPTIONS = {
   "vintage-oldest": t`Vintage Oldest`,
 } as const;
 
+/** Sort projects by big number price @todo extract as a generic BigNumber sort fn */
+const projectPriceSort = (a: Project, b: Project) =>
+  BigNumber.from(a.price).lt(BigNumber.from(b.price)) ? -1 : 1;
+
 /** A Collection of sort functions keyed by sort option */
 export const PROJECT_SORT_FNS: Record<string, IdentityFn<Project[]>> = {
-  "price-highest": sortBy<Project>("price", "desc"),
-  "price-lowest": sortBy<Project>("price"),
+  "price-highest": (projects: Project[]) =>
+    projects.sort(projectPriceSort).reverse(),
+  "price-lowest": (projects: Project[]) => projects.sort(projectPriceSort),
   "recently-updated": sortBy<Project>("updatedAt", "desc"),
   "vintage-newest": sortBy<Project>("vintage", "desc"),
   "vintage-oldest": sortBy<Project>("vintage"),


### PR DESCRIPTION
## Description

`Project.price` is a BigNumber and so the default sort function provided by `lodash.sortBy` couldn't handle them big numbers.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #304 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
