### PR TITLE
fix: add white text for retire button

### DIFF
--- a/carbonmark/components/pages/Portfolio/AssetProject/styles.ts
+++ b/carbonmark/components/pages/Portfolio/AssetProject/styles.ts
@@ -21,4 +21,8 @@ export const tags = css`
 export const buttons = css`
   display: flex;
   gap: 2rem;
+
+  & a {
+    color: var(--white);
+  }
 `;


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Retire button text is blue. This changes the text on the retire button to white.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #341 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
