### PR TITLE
Hide token dust on project page

### DIFF
--- a/carbonmark/components/pages/Project/index.tsx
+++ b/carbonmark/components/pages/Project/index.tsx
@@ -43,7 +43,10 @@ export const Project: NextPage<Props> = (props) => {
       getActiveListings(props.project.listings)) ||
     [];
   const poolPrices =
-    (Array.isArray(props.project?.prices) && props.project.prices) || [];
+    (Array.isArray(props.project?.prices) &&
+      // Remove pool prices if the quantity is less than 1. (leftover  token 'dust')
+      props.project.prices.filter((p) => Number(p.leftToSell) > 1)) ||
+    [];
 
   const sortedListingsAndPrices = sortPricesAndListingsByBestPrice(
     poolPrices,


### PR DESCRIPTION
## Description

Don't show pool prices if they have less than 1 tonne.

## Related Ticket

We need to do this for /projects as well via the backend, see #365 

Otherwise the user could end up on a page that has no listings at all (1 pool  price with < 1 tonne)

Resolves #269 

## Changes

![image](https://user-images.githubusercontent.com/88635679/226484633-324d1faf-eee7-40af-a446-5b9961c6e166.png)
