### PR TITLE
fix #364 - handle js math overflow

### DIFF
--- a/carbonmark/components/pages/Project/Purchase/PurchaseForm.tsx
+++ b/carbonmark/components/pages/Project/Purchase/PurchaseForm.tsx
@@ -1,4 +1,4 @@
-import { formatUnits, getTokenDecimals, useWeb3 } from "@klimadao/lib/utils";
+import { formatUnits, useWeb3 } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { InputField } from "components/shared/Form/InputField";
@@ -9,6 +9,7 @@ import { getUSDCBalance } from "lib/actions";
 import { CARBONMARK_FEE } from "lib/constants";
 import { formatToPrice } from "lib/formatNumbers";
 import { carbonmarkTokenInfoMap } from "lib/getTokenInfo";
+import { getTokenDecimals } from "lib/networkAware/getTokenDecimals";
 import { Listing } from "lib/types/carbonmark";
 import { useRouter } from "next/router";
 import { FC, useEffect, useState } from "react";
@@ -27,17 +28,18 @@ const TotalValue: FC<TotalValueProps> = (props) => {
   const amount = useWatch({ name: "amount", control: props.control });
   const price = Number(props.singlePrice) * Number(amount);
   const totalPrice = price + price * CARBONMARK_FEE || 0;
-
+  const totalPriceTrimmed = totalPrice.toFixed(getTokenDecimals("usdc")); // deal with js math overflows
+  const totalPriceFormatted = parseFloat(totalPriceTrimmed).toString(); // trim trailing zeros
   useEffect(() => {
     // setValue on client only to prevent infinite loop
-    props.setValue("price", totalPrice.toString());
+    props.setValue("price", totalPriceFormatted);
   }, [amount]);
 
   return (
     <>
       <HighlightValue
-        label={t`Cost incl. ${CARBONMARK_FEE * 100}% fee`}
-        value={formatToPrice(totalPrice, locale)}
+        label={t`Listing cost, incl. ${CARBONMARK_FEE * 100}% fee`}
+        value={formatToPrice(totalPriceFormatted, locale)}
         icon={carbonmarkTokenInfoMap["usdc"].icon}
         warn={!!props.errorMessage}
       />

--- a/carbonmark/lib/formatNumbers.ts
+++ b/carbonmark/lib/formatNumbers.ts
@@ -1,9 +1,9 @@
 import { formatUnits, trimWithLocale } from "@klimadao/lib/utils";
-import { BigNumber } from "ethers";
+import { BigNumber, BigNumberish } from "ethers";
 import { getTokenDecimals } from "lib/networkAware/getTokenDecimals";
 
 /** USDC only */
-export const formatBigToPrice = (value: BigNumber, locale = "en") => {
+export const formatBigToPrice = (value: BigNumberish, locale = "en") => {
   const toNumber = Number(formatUnits(value, getTokenDecimals("usdc")));
   return formatToPrice(toNumber, locale);
 };

--- a/carbonmark/lib/types/carbonmark.ts
+++ b/carbonmark/lib/types/carbonmark.ts
@@ -60,7 +60,8 @@ export type Listing = {
   deleted: boolean; // user deleted this listing
   batches: [];
   batchPrices: [];
-  singleUnitPrice: BigNumber;
+  /** Unformatted USDC e.g. 1000000 */
+  singleUnitPrice: string;
   project: {
     id: string;
     key: string;

--- a/lib/utils/formatUnits/index.ts
+++ b/lib/utils/formatUnits/index.ts
@@ -1,6 +1,6 @@
-import { BigNumber, utils } from "ethers";
+import { BigNumberish, utils } from "ethers";
 
 /** Klima and sklima are 9 decimals, USDC 6, all others 18 */
-export const formatUnits = (value: BigNumber, decimals: 6 | 9 | 18 = 18) => {
+export const formatUnits = (value: BigNumberish, decimals: 6 | 9 | 18 = 18) => {
   return utils.formatUnits(value, decimals);
 };


### PR DESCRIPTION
## Description

Multiplication sometimes causes a stray decimal overflow which breaks approvals. This is the best way I could think to fix it.

Resolves KlimaDAO/bezos-frontend#364

