### PR TITLE
Remove/hide Featured Articles component for MVP

### DIFF
--- a/carbonmark/components/pages/Resources/index.tsx
+++ b/carbonmark/components/pages/Resources/index.tsx
@@ -1,14 +1,11 @@
-import { GridContainer, Section } from "@klimadao/lib/components";
-import { t, Trans } from "@lingui/macro";
+import { GridContainer } from "@klimadao/lib/components";
+import { t } from "@lingui/macro";
 import { Footer } from "components/Footer";
 import { PageHead } from "components/PageHead";
 import { Navigation } from "components/shared/Navigation";
-import { Text } from "components/Text";
 import { Document, FeaturedPost } from "lib/queries";
 import { NextPage } from "next";
-import { ArticlesSlider } from "./FeaturedArticles/ArticlesSlider";
 import { ResourcesList } from "./ResourcesList";
-import * as styles from "./styles";
 
 export interface Props {
   documents: Document[];
@@ -26,7 +23,8 @@ export const Resources: NextPage<Props> = (props) => {
 
       <Navigation activePage="Resources" showThemeToggle={false} />
 
-      {!!props.featuredArticles?.length && (
+      {/* hide featured articles for now */}
+      {/* {!!props.featuredArticles?.length && (
         <Section variant="gray" className={styles.sectionHead}>
           <div className={styles.header}>
             <Text t="h1" align="center">
@@ -40,12 +38,11 @@ export const Resources: NextPage<Props> = (props) => {
           </div>
         </Section>
       )}
-
       {!!props.featuredArticles?.length && (
         <Section variant="gray" style={{ padding: "unset" }}>
           <ArticlesSlider articles={props.featuredArticles} />
         </Section>
-      )}
+      )} */}
 
       <ResourcesList documents={props.documents} />
 


### PR DESCRIPTION
## Description

* Featured Article component on [/resources](https://www.carbonmark.com/resources) page is a bit janky for MVP launch, hide for now and we can fix this up for a future release.

Resolves #368 

<!-- If there are UI changes, please include a before and after screenshot in the following template:
## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
