### PR TITLE
Projects: Remove massive scrollbar from card

### DIFF
--- a/carbonmark/components/pages/Projects/styles.ts
+++ b/carbonmark/components/pages/Projects/styles.ts
@@ -62,7 +62,7 @@ export const cardDescription = css`
   -webkit-text-fill-color: transparent;
   background-clip: text;
   max-height: 9rem;
-  overflow-y: hidden;
+  overflow: hidden;
 `;
 
 export const cardImage = css`


### PR DESCRIPTION
## Description

Remove massive scrollbar on project description text which doesn't break

## Related Ticket

Closes https://github.com/Atmosfearful/bezos-frontend/issues/382


## Changes

| Before  | After  |
|---------|--------|
| <img width="413" alt="Bildschirm­foto 2023-03-22 um 21 00 14" src="https://user-images.githubusercontent.com/95881624/227025216-2ce6ff62-705e-4b57-aac6-9fdafe588200.png"> | <img width="385" alt="Bildschirm­foto 2023-03-22 um 21 02 22" src="https://user-images.githubusercontent.com/95881624/227025278-f030bcef-8cdd-4302-bbd7-8f8adde28cc2.png">
 |


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
