### PR TITLE
Fix ProjectFilterModal spacing

### DIFF
--- a/carbonmark/components/Accordion/styles.ts
+++ b/carbonmark/components/Accordion/styles.ts
@@ -4,10 +4,10 @@ import * as typography from "theme/typography";
 export const main = css`
   width: 100%;
   border-bottom: 1px solid var(--surface-02);
+  padding: 0.6rem 0;
 
   .content {
-    padding: 0 0.4rem;
-    padding-bottom: 1rem;
+    padding: 1rem 0.4rem;
     overflow: hidden;
     display: none;
     max-height: 0;

--- a/carbonmark/components/ProjectFilterModal/styles.ts
+++ b/carbonmark/components/ProjectFilterModal/styles.ts
@@ -6,11 +6,11 @@ export const main = css`
     &:first-of-type {
       margin-top: 1.8rem;
     }
+    margin: 0.3rem 0;
   }
 
   form {
     display: grid;
-    grid-gap: inherit;
   }
 
   .modalContent {
@@ -28,6 +28,7 @@ export const main = css`
   .dropdown {
     text-align: left;
     width: 100%;
+    margin-bottom: 1.4rem;
     button {
       width: 100%;
     }


### PR DESCRIPTION
## Description

Clean up the spacing and grouping of elements in the ProjectFilterModal


## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/7104689/227107601-eb71c98f-8269-4bcf-b90c-29553a44e513.png)|![image](https://user-images.githubusercontent.com/7104689/227107440-93b0707f-1bab-4fba-9dea-82b5d2bcd7ac.png)|


## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
