### PR TITLE
[DRAFT] 296 - Remove safari webkit border-radius

### DIFF
--- a/carbonmark/components/SearchInput/styles.ts
+++ b/carbonmark/components/SearchInput/styles.ts
@@ -1,6 +1,9 @@
 import { css } from "@emotion/css";
 
 export const input = css`
+  // This is to override safari's rounded corners behaviour
+  -webkit-border-radius: 0;
+  -webkit-appearance: none;
   background: var(--surface-01);
   border: unset;
   border-radius: var(--border-radius) 0 0 var(--border-radius);


### PR DESCRIPTION
## Description

Removes safari's webkit border radius for search inputs

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #296 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
|img here |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have run `npm run build-all` without errors
- [ ] I have formatted JS and TS files with `npm run format-all`
