### PR TITLE
402 - Override klima-green links with carbonmark blue theme

### DIFF
--- a/carbonmark/pages/_app.tsx
+++ b/carbonmark/pages/_app.tsx
@@ -15,6 +15,8 @@ import "@klimadao/lib/theme/variables.css";
 import "@klimadao/carbonmark/theme/variables.css"; // overrides for variables.css - must be imported after
 // organize-imports-ignore
 import "@klimadao/lib/theme/globals.css"; // depends on variables
+// organize-imports-ignore
+import "@klimadao/carbonmark/theme/globals.css"; // carbonmark specific overrides for globals.css
 
 const loadFallbackOnServer = async () => {
   if (typeof window === "undefined") {

--- a/carbonmark/theme/globals.css
+++ b/carbonmark/theme/globals.css
@@ -1,0 +1,8 @@
+a {
+  text-decoration: none;
+  color: var(--bright-blue);
+}
+a:hover,
+a:visited {
+  color: var(--bright-blue);
+}


### PR DESCRIPTION
## Description

Introduce a globals.css for carbonmark and override `a` tag styling to match carbonmark blue

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves KlimaDAO/bezos-frontend#402 & KlimaDAO/klimadao#983

## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/7104689/227389608-211684a4-8b19-4aa7-8fb4-6bd9382b1282.png)|![image](https://user-images.githubusercontent.com/7104689/227389570-553216b1-e4f6-4a1d-91ca-1efc2923d4d0.png)|

## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
