### PR TITLE
fix wrapping issues on profile view and blog views on mobile

### DIFF
--- a/carbonmark/components/pages/Blog/Post/styles.ts
+++ b/carbonmark/components/pages/Blog/Post/styles.ts
@@ -68,7 +68,13 @@ export const blogContainer = css`
 export const content = css`
   grid-column: main;
   max-width: 76rem;
-  justify-self: center;
+  justify-self: auto;
+  overflow-wrap: break-word;
+
+  ${breakpoints.large} {
+    justify-self: center;
+    overflow-wrap: unset;
+  }
 `;
 
 export const date = css`

--- a/carbonmark/components/pages/Users/ProfileHeader/styles.tsx
+++ b/carbonmark/components/pages/Users/ProfileHeader/styles.tsx
@@ -29,12 +29,15 @@ export const profileLogo = css`
 `;
 
 export const titles = css`
-  white-space: nowrap;
+  white-space: normal;
+  word-break: break-word;
   width: 100%;
   display: flex;
   flex-direction: column;
   gap: 0rem;
+
   ${breakpoints.desktop} {
+    white-space: nowrap;
     flex-direction: row;
     gap: 2rem;
   }


### PR DESCRIPTION
## Description

<!-- Does this PR need additional hands-on QA? Please make a note and notify the relevant testers -->

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Addresses some text wrapping issues on mobile - for blog screens and profile screen.

## Related Ticket

<!-- If your changes are related to a github ticket, please provide the issue number: -->

Resolves #425 

<!-- If there are UI changes, please include a before and after screenshot in the following template:

## Changes

| Before  | After  |
|---------|--------|
| |img here|

-->

## Checklist

<!-- Check completed item: [X] -->

- [X] I have run `npm run build-all` without errors
- [X] I have formatted JS and TS files with `npm run format-all`
