### PR TITLE
fix: Primary Button Disabled Colour Alignment

### DIFF
--- a/carbonmark/components/Buttons/styles.ts
+++ b/carbonmark/components/Buttons/styles.ts
@@ -46,8 +46,8 @@ export const buttonPrimary = css`
   }
 
   &:disabled {
-    background-color: var(--surface-02);
-    color: var(--font-03);
+    color: var(--white);
+    opacity: 0.4;
   }
 `;
 


### PR DESCRIPTION
## Description

Carbonmark colours on disabled primary buttons

## Changes

| Before  | After  |
|---------|--------|
|![image](https://user-images.githubusercontent.com/7104689/229006001-2275b0db-f27e-4d02-b937-e76dc9fecf0c.png)|![image](https://user-images.githubusercontent.com/7104689/229005943-c821837f-3830-4310-870b-d2b8babec8fe.png)|


