### PR TITLE
Edit Listing: Get correct helper for USDCs

### DIFF
--- a/carbonmark/components/pages/Users/SellerConnected/Forms/EditListing.tsx
+++ b/carbonmark/components/pages/Users/SellerConnected/Forms/EditListing.tsx
@@ -1,13 +1,10 @@
-import {
-  formatTonnes,
-  formatUnits,
-  getTokenDecimals,
-} from "@klimadao/lib/utils";
+import { formatTonnes, formatUnits } from "@klimadao/lib/utils";
 import { t, Trans } from "@lingui/macro";
 import { ButtonPrimary } from "components/Buttons/ButtonPrimary";
 import { InputField } from "components/shared/Form/InputField";
 import { Text } from "components/Text";
 import { MINIMUM_TONNE_PRICE } from "lib/constants";
+import { getTokenDecimals } from "lib/networkAware/getTokenDecimals";
 import { Listing } from "lib/types/carbonmark";
 import { useRouter } from "next/router";
 import { FC } from "react";
@@ -136,7 +133,7 @@ export const EditListing: FC<Props> = (props) => {
                   }),
                 },
                 min: {
-                  value: 0.1,
+                  value: MINIMUM_TONNE_PRICE,
                   message: t({
                     id: "user.listing.form.input.singleUnitPrice.minimum",
                     message: `The minimum price per tonne is ${MINIMUM_TONNE_PRICE.toLocaleString(


### PR DESCRIPTION
## Description

If on testnet => the USDC was formatted incorrectly

## Changes

| Before  | After  |
|---------|--------|
|<img width="652" alt="Bildschirm­foto 2023-04-03 um 16 58 16" src="https://user-images.githubusercontent.com/95881624/229549274-a199b580-fb63-4223-b4fa-d619f4c5fb7f.png"> |<img width="656" alt="Bildschirm­foto 2023-04-03 um 16 58 21" src="https://user-images.githubusercontent.com/95881624/229549314-cc0f8e9c-bd07-4672-8e7d-bf03a48687d4.png">|




## Checklist

<!-- Check completed item: [X] -->

- [x] I have run `npm run build-all` without errors
- [x] I have formatted JS and TS files with `npm run format-all`
